### PR TITLE
fix: resolve calendar and contacts page import error

### DIFF
--- a/apps/web/src/app/app/calendar/page.tsx
+++ b/apps/web/src/app/app/calendar/page.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { AppShell } from '@/components/app/AppShell';
-import EnhancedCalendar from '@/components/calendar/EnhancedCalendar';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
+import AppShell from "@/components/app/AppShell";
+import EnhancedCalendar from "@/components/calendar/EnhancedCalendar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import { 
   Calendar, 
   Search, 

--- a/apps/web/src/app/app/contacts/page.tsx
+++ b/apps/web/src/app/app/contacts/page.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { AppShell } from '@/components/app/AppShell';
-import EnhancedContacts from '@/components/contacts/EnhancedContacts';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
+import AppShell from "@/components/app/AppShell";
+import EnhancedContacts from "@/components/contacts/EnhancedContacts";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import { 
   Users, 
   Search, 


### PR DESCRIPTION
## Summary
- fix AppShell import on calendar page
- fix AppShell import on contacts page
- use double quotes for internal imports on calendar and contacts pages

## Testing
- `npm run lint` (fails: recursive turbo invocations)
- `npm test` (fails: recursive turbo invocations)


------
https://chatgpt.com/codex/tasks/task_e_68a4c3c8fee883259f4194695b40ff51