### PR TITLE
feat: add global chat assistant

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import "./globals.css";
 import "@/worker/startWorkers";
 
 import ClientProviders from "@/components/providers/ClientProviders";
+import ChatWidget from "@/components/common/ChatWidget";
 
 const geistSans = Inter({
   variable: "--font-inter",
@@ -107,6 +108,7 @@ export default function RootLayout({
       >
         <ClientProviders>
           {children}
+          <ChatWidget />
         </ClientProviders>
       </body>
     </html>

--- a/apps/web/src/components/common/ChatWidget.tsx
+++ b/apps/web/src/components/common/ChatWidget.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+import { MessageCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { usePathname } from "next/navigation";
+
+const ChatAgent = dynamic(() => import("@/components/app/ChatAgent"), {
+  ssr: false,
+});
+
+export default function ChatWidget() {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+
+  if (pathname?.startsWith("/app")) {
+    return null;
+  }
+
+  return (
+    <>
+      <ChatAgent isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <Button
+        onClick={() => setIsOpen(true)}
+        className="fixed bottom-6 right-6 rounded-full h-12 w-12 shadow-lg brand-gradient text-white"
+        aria-label="Open chat assistant"
+      >
+        <MessageCircle className="h-6 w-6" />
+      </Button>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable ChatWidget to open AI-powered assistant
- include ChatWidget in root layout so marketing pages have quick help access

## Testing
- `npm test` *(fails: recursive turbo invocations)*
- `npm run lint` *(fails: recursive turbo invocations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c20942f88325b3fd1c40c5097e54