### PR TITLE
Clarify member delete permissions and add test

### DIFF
--- a/apps/web/src/lib/security.test.ts
+++ b/apps/web/src/lib/security.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('@/server/auth', () => ({ auth: vi.fn() }));
+vi.mock('next/headers', () => ({ headers: vi.fn() }));
+
+import { hasPermission, type SecurityContext } from './security';
+
+describe('hasPermission for member delete', () => {
+  const context: SecurityContext = {
+    userId: 'user1',
+    userEmail: 'user@example.com',
+    orgId: 'org1',
+    role: 'member'
+  };
+
+  test('allows deleting tasks and notes', () => {
+    expect(hasPermission(context, 'task', 'delete')).toBe(true);
+    expect(hasPermission(context, 'note', 'delete')).toBe(true);
+  });
+
+  test('disallows deleting other resources', () => {
+    expect(hasPermission(context, 'lead', 'delete')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/security.ts
+++ b/apps/web/src/lib/security.ts
@@ -84,7 +84,7 @@ export function hasPermission(
       case 'write':
         return ['lead', 'contact', 'task', 'note'].includes(resource);
       case 'delete':
-        return ['task', 'note'].includes(resource); // Can only delete their own tasks/notes
+        return ['task', 'note'].includes(resource); // Can delete tasks and notes
       case 'admin':
         return false;
       default:


### PR DESCRIPTION
## Summary
- fix comment on member delete permissions
- add unit test for member deletion behavior

## Testing
- `npm test` *(fails: Playwright tests require environment)*
- `npx vitest run src/lib/security.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4c1debea88325976eb8c4f9abde20