### PR TITLE
test(button): ensure disabled button does not trigger click handler

### DIFF
--- a/apps/web/src/components/ui/__tests__/button.test.tsx
+++ b/apps/web/src/components/ui/__tests__/button.test.tsx
@@ -24,9 +24,19 @@ describe('Button', () => {
     expect(button).toHaveClass('bg-gradient-to-r')
   })
 
-  it('can be disabled', () => {
-    render(<Button disabled>Disabled Button</Button>)
+  it('can be disabled', async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+
+    render(
+      <Button onClick={handleClick} disabled>
+        Disabled Button
+      </Button>
+    )
+
     const button = screen.getByRole('button')
+    await user.click(button)
+    expect(handleClick).not.toHaveBeenCalled()
     expect(button).toBeDisabled()
     expect(button).toHaveClass('disabled:pointer-events-none')
   })


### PR DESCRIPTION
## Summary
- add onClick mock to disabled button test to ensure handler isn't called

## Testing
- `npx vitest src/components/ui/__tests__/button.test.tsx` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a4c0f87d548325853e08ed91e7968d