### PR TITLE
feat: add streaming AI assistant

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -70,6 +70,8 @@ REDIS_URL=redis://localhost:6379
 
 # Get from https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-your-openai-api-key-here
+# Generic AI key for hosted LLM
+AI_API_KEY=your-ai-api-key
 
 # =============================================================================
 # ENCRYPTION & SECURITY (simplified for local dev)

--- a/apps/web/src/app/api/ai/assistant/route.ts
+++ b/apps/web/src/app/api/ai/assistant/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server';
+import { streamAssistantResponse } from '@/server/ai/assistant';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { message, leadId, property } = await req.json();
+    if (!message || typeof message !== 'string') {
+      return new Response('Message required', { status: 400 });
+    }
+    const stream = await streamAssistantResponse({ prompt: message, leadId, property });
+    return new Response(stream);
+  } catch (err) {
+    console.error('Assistant API error:', err);
+    return new Response('Failed to process message', { status: 500 });
+  }
+}

--- a/apps/web/src/components/app/ChatAgent.tsx
+++ b/apps/web/src/components/app/ChatAgent.tsx
@@ -41,64 +41,6 @@ interface ChatAgentProps {
   onClose: () => void;
 }
 
-// Knowledge base for the chat agent
-const KNOWLEDGE_BASE = {
-  dashboard: {
-    title: "Dashboard Overview",
-    content: "The dashboard is your command center. You can customize it by clicking the 'Customize' button to rearrange cards, add new ones, or change layouts. Each card shows different insights about your leads, pipeline, and system health.",
-    tips: [
-      "Drag cards to rearrange them in edit mode",
-      "Click the gear icon on cards for quick actions",
-      "Use the search bar to find specific information"
-    ]
-  },
-  inbox: {
-    title: "Inbox Management",
-    content: "Your inbox automatically detects leads from emails and organizes them. You can compose new emails, set up auto-responses, and track email engagement.",
-    tips: [
-      "Set up email integrations to automatically detect leads",
-      "Use AI to draft follow-up emails",
-      "Create email templates for common responses"
-    ]
-  },
-  pipeline: {
-    title: "Pipeline Management",
-    content: "The pipeline helps you track leads through your sales process. Create stages, move leads between them, and analyze conversion rates.",
-    tips: [
-      "Create custom stages that match your sales process",
-      "Use the pipeline view to see all leads at once",
-      "Set up automated actions when leads move stages"
-    ]
-  },
-  calendar: {
-    title: "Calendar Integration",
-    content: "Connect your calendar to automatically detect meetings and create leads from attendees. Schedule follow-ups and track meeting outcomes.",
-    tips: [
-      "Connect Google Calendar or Outlook",
-      "Set up meeting templates",
-      "Automatically create leads from meeting attendees"
-    ]
-  },
-  contacts: {
-    title: "Contact Management",
-    content: "Manage all your contacts in one place. Import contacts, track interactions, and maintain detailed profiles.",
-    tips: [
-      "Import contacts from CSV or other CRM systems",
-      "Add custom fields to track important information",
-      "Use tags to organize contacts"
-    ]
-  },
-  chat: {
-    title: "AI Chat Assistant",
-    content: "The AI chat helps you draft emails, analyze leads, and get insights about your sales process.",
-    tips: [
-      "Ask the AI to draft follow-up emails",
-      "Get suggestions for lead qualification",
-      "Request analysis of your pipeline performance"
-    ]
-  }
-};
-
 export default function ChatAgent({ isOpen, onClose }: ChatAgentProps) {
   const [messages, setMessages] = useState<Message[]>([
     {
@@ -159,112 +101,74 @@ export default function ChatAgent({ isOpen, onClose }: ChatAgentProps) {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
-  const handleSendMessage = async () => {
-    if (!inputValue.trim()) return;
-
+  const sendPrompt = async (prompt: string) => {
     const userMessage: Message = {
       id: Date.now().toString(),
       type: 'user',
-      content: inputValue,
+      content: prompt,
       timestamp: new Date()
     };
 
     setMessages(prev => [...prev, userMessage]);
-    setInputValue('');
     setIsTyping(true);
 
-    // Simulate AI response
-    setTimeout(() => {
-      const response = generateResponse(inputValue);
-      const assistantMessage: Message = {
-        id: (Date.now() + 1).toString(),
-        type: 'assistant',
-        content: response.content,
-        timestamp: new Date(),
-        suggestions: response.suggestions
-      };
+    try {
+      const response = await fetch('/api/ai/assistant', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: prompt })
+      });
 
+      const assistantId = (Date.now() + 1).toString();
+      const assistantMessage: Message = {
+        id: assistantId,
+        type: 'assistant',
+        content: '',
+        timestamp: new Date()
+      };
       setMessages(prev => [...prev, assistantMessage]);
+
+      if (response.body) {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let done = false;
+        while (!done) {
+          const { value, done: readerDone } = await reader.read();
+          done = readerDone;
+          if (value) {
+            const chunk = decoder.decode(value);
+            setMessages(prev => prev.map(m => m.id === assistantId ? { ...m, content: m.content + chunk } : m));
+          }
+        }
+      } else {
+        setMessages(prev => prev.map(m => m.id === assistantId ? { ...m, content: 'No response from assistant.' } : m));
+      }
+    } catch (error) {
+      console.error('Assistant error', error);
+      const errorMessage: Message = {
+        id: `assistant_${Date.now()}`,
+        type: 'assistant',
+        content: 'Sorry, I encountered an error. Please try again.',
+        timestamp: new Date()
+      };
+      setMessages(prev => [...prev, errorMessage]);
+    } finally {
       setIsTyping(false);
-    }, 1000);
+      scrollToBottom();
+    }
+  };
+
+  const handleSendMessage = async () => {
+    if (!inputValue.trim()) return;
+    const prompt = inputValue;
+    setInputValue('');
+    await sendPrompt(prompt);
   };
 
   const handleQuickAction = (actionId: string) => {
     const action = quickActions.find(a => a.id === actionId);
     if (!action) return;
-
-    const userMessage: Message = {
-      id: Date.now().toString(),
-      type: 'user',
-      content: action.title,
-      timestamp: new Date()
-    };
-
-    setMessages(prev => [...prev, userMessage]);
-    setIsTyping(true);
-
-    setTimeout(() => {
-      const response = generateResponse(action.title);
-      const assistantMessage: Message = {
-        id: (Date.now() + 1).toString(),
-        type: 'assistant',
-        content: response.content,
-        timestamp: new Date(),
-        suggestions: response.suggestions
-      };
-
-      setMessages(prev => [...prev, assistantMessage]);
-      setIsTyping(false);
-    }, 800);
-  };
-
-  const generateResponse = (query: string): { content: string; suggestions?: string[] } => {
-    const lowerQuery = query.toLowerCase();
-    
-    // Check knowledge base
-    for (const [key, info] of Object.entries(KNOWLEDGE_BASE)) {
-      if (lowerQuery.includes(key) || info.title.toLowerCase().includes(lowerQuery)) {
-        return {
-          content: `${info.title}\n\n${info.content}\n\n💡 **Quick Tips:**\n${info.tips.map(tip => `• ${tip}`).join('\n')}`,
-          suggestions: ['Dashboard', 'Inbox', 'Pipeline', 'Calendar', 'Contacts', 'Chat']
-        };
-      }
-    }
-
-    // Handle specific queries
-    if (lowerQuery.includes('customize') || lowerQuery.includes('dashboard')) {
-      return {
-        content: "To customize your dashboard:\n\n1. Click the 'Customize' button (bottom right)\n2. Drag cards to rearrange them\n3. Use the 'Add Cards' button to add new widgets\n4. Choose from different layout presets\n5. Click 'Save & Exit' when done",
-        suggestions: ['Pipeline', 'Inbox', 'Integrations']
-      };
-    }
-
-    if (lowerQuery.includes('integrations') || lowerQuery.includes('setup')) {
-      return {
-        content: "To set up integrations:\n\n1. Go to Settings → Integrations\n2. Click 'Connect Gmail' or 'Connect Calendar'\n3. Follow the OAuth flow\n4. Grant necessary permissions\n5. Your data will start syncing automatically",
-        suggestions: ['Dashboard', 'Pipeline', 'Calendar']
-      };
-    }
-
-    if (lowerQuery.includes('pipeline') || lowerQuery.includes('stages')) {
-      return {
-        content: "To create your pipeline:\n\n1. Go to Settings → Pipeline\n2. Click 'Add Stage' to create new stages\n3. Drag stages to reorder them\n4. Set colors and names for each stage\n5. Add automation rules if needed",
-        suggestions: ['Dashboard', 'Leads', 'Analytics']
-      };
-    }
-
-    if (lowerQuery.includes('ai') || lowerQuery.includes('features')) {
-      return {
-        content: "Rivor's AI features include:\n\n🤖 **Email Drafting**: AI helps compose follow-up emails\n📊 **Lead Analysis**: Get insights about lead quality\n📈 **Pipeline Optimization**: AI suggests improvements\n💬 **Smart Responses**: Auto-generate contextual replies\n📋 **Task Automation**: AI creates tasks based on interactions",
-        suggestions: ['Dashboard', 'Inbox', 'Pipeline']
-      };
-    }
-
-    // Default response
-    return {
-      content: "I can help you with:\n\n• Dashboard customization and navigation\n• Setting up email and calendar integrations\n• Creating and managing your sales pipeline\n• Using AI features for lead management\n• Understanding analytics and reports\n\nWhat specific area would you like to learn more about?",
-      suggestions: ['Dashboard', 'Integrations', 'Pipeline', 'AI Features']
-    };
+    sendPrompt(action.title);
   };
 
   const handleSuggestionClick = (suggestion: string) => {

--- a/apps/web/src/server/ai/assistant.ts
+++ b/apps/web/src/server/ai/assistant.ts
@@ -1,0 +1,119 @@
+import { prisma } from '@/server/db';
+import { auth } from '@/server/auth';
+
+interface AssistantParams {
+  prompt: string;
+  leadId?: string;
+  property?: Record<string, any>;
+}
+
+/**
+ * Forward the prompt to the hosted LLM and stream the response back.
+ */
+export async function streamAssistantResponse(params: AssistantParams) {
+  const session = await auth();
+  if (!session) {
+    throw new Error('Unauthorized');
+  }
+  const orgId = (session as { orgId?: string }).orgId;
+  if (!orgId) {
+    throw new Error('No organization');
+  }
+
+  const { prompt, leadId, property } = params;
+
+  let context = '';
+
+  if (leadId) {
+    const lead = await prisma.lead.findUnique({
+      where: { id: leadId, orgId },
+      include: {
+        contact: true,
+        stage: true,
+      },
+    });
+    if (lead) {
+      context += `Lead:\n`;
+      context += `- Title: ${lead.title || 'Untitled'}\n`;
+      context += `- Status: ${lead.status}\n`;
+      context += `- Priority: ${lead.priority}\n`;
+      context += `- Stage: ${lead.stage?.name || 'None'}\n`;
+      if (lead.probabilityPercent !== null && lead.probabilityPercent !== undefined) {
+        context += `- Probability: ${lead.probabilityPercent}%\n`;
+      }
+      if (lead.contact) {
+        context += `- Contact present\n`;
+      }
+    }
+  }
+
+  if (property) {
+    context += 'Property:\n';
+    for (const [key, value] of Object.entries(property)) {
+      context += `- ${key}: ${value}\n`;
+    }
+  }
+
+  const systemPrompt = `You are a helpful real estate assistant. Use the provided context to answer questions.\n${context}`;
+
+  const apiKey = process.env.AI_API_KEY;
+  if (!apiKey) {
+    throw new Error('AI_API_KEY not configured');
+  }
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      stream: true,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+    }),
+  });
+
+  if (!response.body) {
+    throw new Error('No response body');
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      const encoder = new TextEncoder();
+      let buffer = '';
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          if (trimmed === 'data: [DONE]') {
+            controller.close();
+            return;
+          }
+          if (trimmed.startsWith('data:')) {
+            try {
+              const data = JSON.parse(trimmed.replace(/^data: /, ''));
+              const content: string | undefined = data.choices?.[0]?.delta?.content;
+              if (content) controller.enqueue(encoder.encode(content));
+            } catch {
+              // ignore JSON parse errors
+            }
+          }
+        }
+      }
+      controller.close();
+    },
+  });
+
+  return stream;
+}

--- a/apps/web/src/server/env.ts
+++ b/apps/web/src/server/env.ts
@@ -24,6 +24,7 @@ export type Env = {
   POSTHOG_HOST?: string;
   OPENAI_API_KEY?: string;
   OPENAI_BASE_URL?: string;
+  AI_API_KEY?: string;
   KMS_PROVIDER?: 'gcp'|'aws'|'azure';
   KMS_KEY_ID?: string;
   ENCRYPTION_CACHE_TTL_SECONDS: number;
@@ -60,6 +61,7 @@ export function getEnv(): Env {
     POSTHOG_HOST: env.POSTHOG_HOST,
     OPENAI_API_KEY: env.OPENAI_API_KEY,
     OPENAI_BASE_URL: env.OPENAI_BASE_URL,
+    AI_API_KEY: env.AI_API_KEY,
     KMS_PROVIDER: env.KMS_PROVIDER as Env['KMS_PROVIDER'],
     KMS_KEY_ID: env.KMS_KEY_ID,
     ENCRYPTION_CACHE_TTL_SECONDS: Number(env.ENCRYPTION_CACHE_TTL_SECONDS ?? 60),

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -27,6 +27,7 @@ export const EnvSchema = z.object({
   POSTHOG_HOST: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
+  AI_API_KEY: z.string().optional(),
   KMS_PROVIDER: z.enum(['gcp','aws','azure']).optional(),
   KMS_KEY_ID: z.string().optional(),
   ENCRYPTION_CACHE_TTL_SECONDS: z.coerce.number().default(60),

--- a/scripts/setup-local-dev.bat
+++ b/scripts/setup-local-dev.bat
@@ -44,9 +44,10 @@ if not exist "%ENV_FILE%" (
         echo REDIS_URL=redis://localhost:6379
         echo.
         echo # =============================================================================
-        echo # AI INTEGRATION - FILL THIS IN FROM OPENAI
+        echo # AI INTEGRATION - FILL THESE IN
         echo # =============================================================================
         echo OPENAI_API_KEY=sk-your-openai-api-key-here
+        echo AI_API_KEY=your-ai-api-key
         echo.
         echo # =============================================================================
         echo # ENCRYPTION ^(local development^)
@@ -60,6 +61,7 @@ if not exist "%ENV_FILE%" (
     echo ⚠️  You still need to fill in:
     echo    - GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET
     echo    - OPENAI_API_KEY
+    echo    - AI_API_KEY
 ) else (
     echo ✅ %ENV_FILE% already exists
 )

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -50,9 +50,10 @@ DATABASE_URL=postgresql://postgres:rivor123@localhost:5432/rivor_dev
 REDIS_URL=redis://localhost:6379
 
 # =============================================================================
-# AI INTEGRATION - FILL THIS IN FROM OPENAI
+# AI INTEGRATION - FILL THESE IN
 # =============================================================================
 OPENAI_API_KEY=sk-your-openai-api-key-here
+AI_API_KEY=your-ai-api-key
 
 # =============================================================================
 # ENCRYPTION (local development)
@@ -66,6 +67,7 @@ EOF
     echo "⚠️  You still need to fill in:"
     echo "   - GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET"
     echo "   - OPENAI_API_KEY"
+    echo "   - AI_API_KEY"
 else
     echo "✅ $ENV_FILE already exists"
 fi


### PR DESCRIPTION
## Summary
- add server-side assistant proxy that streams responses from hosted LLM
- wire ChatAgent to new API endpoint instead of mock responses
- support property/lead context and document AI_API_KEY env

## Testing
- `npm test` *(fails: recursive_turbo_invocations)*
- `npm run lint` *(fails: recursive_turbo_invocations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc882c4883259f2a2d9122f60f0e