### PR TITLE
feat: add showings calendar and endpoints

### DIFF
--- a/apps/web/src/components/app/ShowingsCalendar.tsx
+++ b/apps/web/src/components/app/ShowingsCalendar.tsx
@@ -1,0 +1,78 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Calendar, Clock, MapPin, Link as LinkIcon } from "lucide-react";
+import Link from "next/link";
+import { getUpcomingEvents } from "@/server/calendar";
+import { prisma } from "@/server/db";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/server/auth";
+
+async function getOrgId(): Promise<string> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    throw new Error("Not authenticated");
+  }
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    include: {
+      orgMembers: {
+        include: { org: true }
+      }
+    }
+  });
+  const org = user?.orgMembers?.[0]?.org;
+  if (!org) {
+    throw new Error("No organization found");
+  }
+  return org.id;
+}
+
+export default async function ShowingsCalendar() {
+  const orgId = await getOrgId();
+  const events = await getUpcomingEvents(orgId, 20);
+
+  return (
+    <Card className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Calendar className="h-5 w-5" />
+          Upcoming Showings
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {events.length === 0 && (
+          <p className="text-sm text-slate-600 dark:text-slate-400">No upcoming showings</p>
+        )}
+        {events.map(event => {
+          const leadId = event.attendees?.startsWith("lead:")
+            ? event.attendees.split(":")[1]
+            : undefined;
+          return (
+            <div key={event.id} className="space-y-1">
+              <p className="font-medium text-slate-900 dark:text-slate-100">
+                {event.title || "Untitled Showing"}
+              </p>
+              <div className="text-sm text-slate-600 dark:text-slate-400 flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                {new Date(event.start).toLocaleString()}
+              </div>
+              {event.location && (
+                <div className="text-sm text-slate-600 dark:text-slate-400 flex items-center gap-2">
+                  <MapPin className="h-4 w-4" />
+                  {event.location}
+                </div>
+              )}
+              {leadId && (
+                <Link
+                  href={`/app/pipeline?lead=${leadId}`}
+                  className="text-xs text-blue-600 hover:underline flex items-center gap-1"
+                >
+                  <LinkIcon className="h-3 w-3" /> View lead
+                </Link>
+              )}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -1,4 +1,5 @@
 ﻿import { router } from "./trpc";
+import { showingsRouter } from "../showings";
 import { z } from "zod";
 import { publicProcedure, protectedProcedure } from "./trpc";
 import { prisma } from "@/server/db";
@@ -54,6 +55,7 @@ async function getCurrentUser() {
 export const appRouter = router({
   health: publicProcedure.query(() => ({ ok: true })),
   echo: publicProcedure.input(z.object({ text: z.string() })).mutation(({ input }) => ({ text: input.text })),
+  showings: showingsRouter,
 
   // Dashboard Data
   dashboard: protectedProcedure.query(async () => {

--- a/apps/web/src/server/showings.ts
+++ b/apps/web/src/server/showings.ts
@@ -1,0 +1,142 @@
+import { router, protectedProcedure } from "./api/trpc";
+import { z } from "zod";
+import { prisma } from "./db";
+import { encryptForOrg } from "./crypto";
+import { getServerSession } from "next-auth";
+import { authOptions } from "./auth";
+
+async function getCurrentOrgId() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    throw new Error("Not authenticated");
+  }
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    include: {
+      orgMembers: {
+        include: { org: true }
+      }
+    }
+  });
+  const org = user?.orgMembers?.[0]?.org;
+  if (!org) {
+    throw new Error("No organization found");
+  }
+  return org.id;
+}
+
+export const showingsRouter = router({
+  create: protectedProcedure
+    .input(z.object({
+      title: z.string(),
+      start: z.date(),
+      end: z.date(),
+      location: z.string().optional(),
+      attendees: z.array(z.string()).optional(),
+      leadId: z.string().optional(),
+    }))
+    .mutation(async ({ input }) => {
+      const orgId = await getCurrentOrgId();
+      const account = await prisma.calendarAccount.findFirst({
+        where: { orgId },
+        select: { id: true }
+      });
+      if (!account) {
+        throw new Error("No calendar account found");
+      }
+      const event = await prisma.calendarEvent.create({
+        data: {
+          orgId,
+          accountId: account.id,
+          start: input.start,
+          end: input.end,
+          titleEnc: await encryptForOrg(orgId, input.title, "calendar:title"),
+          locationEnc: input.location
+            ? await encryptForOrg(orgId, input.location, "calendar:location")
+            : null,
+          notesEnc: input.leadId
+            ? await encryptForOrg(orgId, `lead:${input.leadId}`, "calendar:notes")
+            : null,
+          attendeesEnc: input.attendees
+            ? await encryptForOrg(orgId, input.attendees.join(","), "calendar:attendees")
+            : null,
+        },
+      });
+
+      let followUpTask = null as any;
+      if (input.leadId) {
+        followUpTask = await prisma.task.create({
+          data: {
+            orgId,
+            title: `Follow up after showing`,
+            dueAt: new Date(input.end.getTime() + 60 * 60 * 1000),
+            linkLeadId: input.leadId,
+            description: `event:${event.id}`,
+          },
+        });
+      }
+
+      return { event, followUpTask };
+    }),
+
+  update: protectedProcedure
+    .input(z.object({
+      id: z.string(),
+      title: z.string().optional(),
+      start: z.date().optional(),
+      end: z.date().optional(),
+      location: z.string().optional(),
+      attendees: z.array(z.string()).optional(),
+      leadId: z.string().optional(),
+    }))
+    .mutation(async ({ input }) => {
+      const orgId = await getCurrentOrgId();
+      const data: any = {};
+      if (input.title !== undefined) {
+        data.titleEnc = await encryptForOrg(orgId, input.title, "calendar:title");
+      }
+      if (input.start !== undefined) data.start = input.start;
+      if (input.end !== undefined) data.end = input.end;
+      if (input.location !== undefined) {
+        data.locationEnc = await encryptForOrg(orgId, input.location, "calendar:location");
+      }
+      if (input.attendees !== undefined) {
+        data.attendeesEnc = await encryptForOrg(orgId, input.attendees.join(","), "calendar:attendees");
+      }
+      if (input.leadId !== undefined) {
+        data.notesEnc = await encryptForOrg(orgId, `lead:${input.leadId}`, "calendar:notes");
+      }
+
+      const event = await prisma.calendarEvent.update({
+        where: { id: input.id, orgId },
+        data,
+      });
+
+      const existingTask = await prisma.task.findFirst({
+        where: { orgId, description: `event:${input.id}` },
+      });
+      let followUpTask = null as any;
+      if (existingTask) {
+        followUpTask = await prisma.task.update({
+          where: { id: existingTask.id },
+          data: {
+            dueAt: input.end
+              ? new Date(input.end.getTime() + 60 * 60 * 1000)
+              : existingTask.dueAt,
+            linkLeadId: input.leadId ?? existingTask.linkLeadId,
+          },
+        });
+      }
+
+      return { event, followUpTask };
+    }),
+
+  cancel: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input }) => {
+      const orgId = await getCurrentOrgId();
+      await prisma.calendarEvent.delete({ where: { id: input.id, orgId } });
+      await prisma.task.deleteMany({ where: { orgId, description: `event:${input.id}` } });
+      return { success: true };
+    }),
+});


### PR DESCRIPTION
## Summary
- display upcoming showings with links to leads
- add showings TRPC endpoints for create/update/cancel with follow-up tasks
- expose showings router via API root

## Testing
- `npx vitest` *(fails: Playwright Test did not expect test.describe to be called, Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc887c18832589883e3fa7a907d5