### PR TITLE
feat: add CRM connectors and sync status UI

### DIFF
--- a/apps/web/src/components/app/LeadFeed.tsx
+++ b/apps/web/src/components/app/LeadFeed.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { GlassCard, GlassCardContent, GlassCardHeader, GlassCardTitle } from '@/components/ui/glass-card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -47,10 +47,29 @@ interface Lead {
 interface LeadFeedProps {
   leads: Lead[];
   reviewItems?: any[];
+  crmSyncStatus?: string;
 }
 
-export default function LeadFeed({ leads = [], reviewItems = [] }: LeadFeedProps) {
+export default function LeadFeed({ leads = [], reviewItems = [], crmSyncStatus }: LeadFeedProps) {
   const [activeTab, setActiveTab] = useState('leads');
+  const [syncStatus, setSyncStatus] = useState(crmSyncStatus || 'idle');
+
+  useEffect(() => {
+    async function fetchStatus() {
+      try {
+        const res = await fetch('/api/crm/status');
+        if (res.ok) {
+          const data = await res.json();
+          setSyncStatus(data.status);
+        }
+      } catch (err) {
+        console.warn('Failed to fetch CRM sync status', err);
+      }
+    }
+    fetchStatus();
+    const id = setInterval(fetchStatus, 60000);
+    return () => clearInterval(id);
+  }, []);
 
   const getIntentFromTitle = (title: string | null): 'buyer' | 'seller' | 'renter' => {
     if (!title) return 'buyer';
@@ -185,8 +204,11 @@ export default function LeadFeed({ leads = [], reviewItems = [] }: LeadFeedProps
 
   return (
     <GlassCard variant="river-flow" intensity="medium" flowDirection="down" className="h-full">
-      <GlassCardHeader className="pb-3">
+      <GlassCardHeader className="pb-3 flex items-center justify-between">
         <GlassCardTitle className="text-lg">Lead Feed</GlassCardTitle>
+        <Badge variant={syncStatus === 'syncing' ? 'secondary' : 'outline'} className="text-xs">
+          {syncStatus === 'syncing' ? 'Syncing…' : syncStatus === 'error' ? 'Sync Error' : 'Synced'}
+        </Badge>
       </GlassCardHeader>
       <GlassCardContent className="p-0">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">

--- a/apps/web/src/server/crm.ts
+++ b/apps/web/src/server/crm.ts
@@ -1,0 +1,118 @@
+import { prisma } from './db';
+import { encryptForOrg, decryptForOrg } from './crypto';
+
+export interface CRMContact {
+  id: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+}
+
+async function getOAuthTokens(orgId: string, provider: 'hubspot' | 'salesforce') {
+  const org = await prisma.org.findUnique({ where: { id: orgId } });
+  if (!org) throw new Error('Organization not found');
+
+  const account = await prisma.oAuthAccount.findFirst({
+    where: {
+      provider,
+      userId: org.name // org.name stores owner email
+    }
+  });
+
+  if (!account) throw new Error(`${provider} OAuth account not found`);
+
+  const accessTokenBytes = await decryptForOrg(orgId, account.accessToken, `oauth:${provider}:access`);
+  const refreshTokenBytes = account.refreshToken
+    ? await decryptForOrg(orgId, account.refreshToken, `oauth:${provider}:refresh`)
+    : undefined;
+
+  const accessToken = new TextDecoder().decode(accessTokenBytes);
+  const refreshToken = refreshTokenBytes ? new TextDecoder().decode(refreshTokenBytes) : undefined;
+
+  return { accessToken, refreshToken, account };
+}
+
+export class HubSpotConnector {
+  constructor(private accessToken: string) {}
+
+  async listContacts(limit = 100): Promise<CRMContact[]> {
+    const res = await fetch(`https://api.hubspot.com/crm/v3/objects/contacts?limit=${limit}`, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json'
+      }
+    });
+    if (!res.ok) throw new Error('HubSpot API error');
+    const data = await res.json();
+    return (data.results || []).map((c: any) => ({
+      id: c.id,
+      email: c.properties?.email,
+      firstName: c.properties?.firstname,
+      lastName: c.properties?.lastname,
+      phone: c.properties?.phone
+    }));
+  }
+}
+
+export class SalesforceConnector {
+  constructor(private accessToken: string, private instanceUrl: string) {}
+
+  async listContacts(limit = 100): Promise<CRMContact[]> {
+    const soql = encodeURIComponent(`SELECT Id, FirstName, LastName, Email, Phone FROM Contact LIMIT ${limit}`);
+    const res = await fetch(`${this.instanceUrl}/services/data/v58.0/query/?q=${soql}`, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json'
+      }
+    });
+    if (!res.ok) throw new Error('Salesforce API error');
+    const data = await res.json();
+    return (data.records || []).map((c: any) => ({
+      id: c.Id,
+      email: c.Email,
+      firstName: c.FirstName,
+      lastName: c.LastName,
+      phone: c.Phone
+    }));
+  }
+}
+
+export async function createHubSpotConnector(orgId: string) {
+  const { accessToken } = await getOAuthTokens(orgId, 'hubspot');
+  return new HubSpotConnector(accessToken);
+}
+
+export async function createSalesforceConnector(orgId: string) {
+  const { accessToken, account } = await getOAuthTokens(orgId, 'salesforce');
+  const instanceUrl = account.providerId || process.env.SALESFORCE_INSTANCE_URL || '';
+  return new SalesforceConnector(accessToken, instanceUrl);
+}
+
+export async function syncContacts(orgId: string, provider: 'hubspot' | 'salesforce') {
+  const connector =
+    provider === 'hubspot'
+      ? await createHubSpotConnector(orgId)
+      : await createSalesforceConnector(orgId);
+
+  const contacts = await connector.listContacts();
+
+  for (const c of contacts) {
+    const name = [c.firstName, c.lastName].filter(Boolean).join(' ');
+    await prisma.contact.create({
+      data: {
+        orgId,
+        nameEnc: name ? await encryptForOrg(orgId, name, 'contact:name') : undefined,
+        emailEnc: c.email ? await encryptForOrg(orgId, c.email, 'contact:email') : undefined,
+        phoneEnc: c.phone ? await encryptForOrg(orgId, c.phone, 'contact:phone') : undefined,
+        source: provider
+      }
+    });
+  }
+}
+
+export async function exportContacts(orgId: string) {
+  const contacts = await prisma.contact.findMany({ where: { orgId } });
+  return contacts;
+}
+


### PR DESCRIPTION
## Summary
- add HubSpot and Salesforce CRM connectors with OAuth token handling
- expose import/export controls in Contacts page and display CRM sync status in LeadFeed
- schedule CRM sync jobs via new queue helpers

## Testing
- `npm test` *(fails: recursive turborepo invocation)*
- `cd apps/web && npm test` *(fails: Playwright configuration and missing @testing-library/dom)*
- `npm run lint` *(fails: recursive turborepo invocation)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc894c8c8325a53c5f7a54065252