### PR TITLE
feat: add lead follow-up automation

### DIFF
--- a/apps/web/src/app/api/pipeline/leads/[leadId]/route.ts
+++ b/apps/web/src/app/api/pipeline/leads/[leadId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/server/auth';
 import { prisma } from '@/server/db';
+import { handleStageChange } from '@/server/automation';
 
 export const dynamic = 'force-dynamic';
 
@@ -61,6 +62,10 @@ export async function PATCH(req: NextRequest, { params }: { params: { leadId: st
           createdBy: session.user.email
         }
       });
+
+      if (existingLead.automationEnabled) {
+        await handleStageChange(orgId, leadId);
+      }
     }
 
     // Handle other updates
@@ -73,6 +78,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { leadId: st
     if (body.priority !== undefined) updateData.priority = body.priority;
     if (body.description !== undefined) updateData.description = body.description;
     if (body.tags !== undefined) updateData.tags = body.tags;
+    if (body.automationEnabled !== undefined) updateData.automationEnabled = body.automationEnabled;
 
     const updatedLead = await prisma.lead.update({
       where: { id: leadId },

--- a/apps/web/src/app/api/pipeline/leads/route.ts
+++ b/apps/web/src/app/api/pipeline/leads/route.ts
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic';
 /**
  * Create new lead
  */
-export async function POST(_req: NextRequest) {
+export async function POST(req: NextRequest) {
   try {
     const session = await auth();
     if (!session?.user?.email) {
@@ -30,10 +30,11 @@ export async function POST(_req: NextRequest) {
       stage,
       priority,
       source,
-      description,
-      tags,
-      threadId
-    } = body;
+        description,
+        tags,
+        threadId,
+        automationEnabled
+      } = body;
 
     if (!title || !company || !contact) {
       return NextResponse.json(
@@ -70,7 +71,8 @@ export async function POST(_req: NextRequest) {
         description: description || null,
         tags: tags || [],
         threadId: threadId || null,
-        status: 'active'
+        status: 'active',
+        automationEnabled: automationEnabled ?? false
       }
     });
 

--- a/apps/web/src/app/api/pipeline/stages/route.ts
+++ b/apps/web/src/app/api/pipeline/stages/route.ts
@@ -100,6 +100,7 @@ export async function GET(_req: NextRequest) {
         description: lead.description,
         createdAt: lead.createdAt.toISOString(),
         updatedAt: lead.updatedAt.toISOString(),
+        automationEnabled: lead.automationEnabled,
         tags: lead.tags || [],
         threadId: lead.threadId,
         activities: lead.activities.map(activity => ({

--- a/apps/web/src/components/pipeline/PipelineBoard.tsx
+++ b/apps/web/src/components/pipeline/PipelineBoard.tsx
@@ -36,6 +36,7 @@ export interface Lead {
   description?: string;
   createdAt: string;
   updatedAt: string;
+  automationEnabled: boolean;
   activities?: Activity[];
   tags: string[];
   threadId?: string; // Link to email thread

--- a/apps/web/src/components/pipeline/PipelineCard.tsx
+++ b/apps/web/src/components/pipeline/PipelineCard.tsx
@@ -11,7 +11,8 @@ import {
   Phone,
   MoreHorizontal,
   TrendingUp,
-  AlertCircle
+  AlertCircle,
+  Zap
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Lead } from './PipelineBoard';
@@ -136,6 +137,20 @@ export default function PipelineCard({ lead, isDragging = false }: PipelineCardP
                 <DropdownMenuItem>
                   <Calendar className="h-4 w-4 mr-2" />
                   Add Meeting
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const enabled = !lead.automationEnabled;
+                    fetch(`/api/pipeline/leads/${lead.id}`, {
+                      method: 'PATCH',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ automationEnabled: enabled })
+                    }).then(() => window.location.reload());
+                  }}
+                >
+                  <Zap className="h-4 w-4 mr-2" />
+                  {lead.automationEnabled ? 'Disable' : 'Enable'} Follow-up
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem>Edit Details</DropdownMenuItem>

--- a/apps/web/src/server/automation.ts
+++ b/apps/web/src/server/automation.ts
@@ -1,0 +1,82 @@
+import { prisma } from './db';
+import { GmailService } from './gmail';
+import { decryptForOrg } from './crypto';
+import { logger } from '@/lib/logger';
+
+/**
+ * Send a templated follow-up email for a lead using the org's first Gmail account
+ */
+export async function sendFollowUpEmail(orgId: string, leadId: string, template: string) {
+  const lead = await prisma.lead.findUnique({
+    where: { id: leadId },
+    include: { contact: true }
+  });
+  if (!lead || !lead.contact?.emailEnc) return;
+
+  try {
+    const emailBytes = await decryptForOrg(orgId, lead.contact.emailEnc as unknown as Buffer, 'contact:email');
+    const to = new TextDecoder().decode(emailBytes);
+
+    const account = await prisma.emailAccount.findFirst({
+      where: { orgId, provider: 'google' }
+    });
+    if (!account) {
+      logger.warn('No Gmail account available for org', { orgId });
+      return;
+    }
+
+    const gmail = await GmailService.createFromAccount(orgId, account.id);
+    await gmail.sendEmail({
+      to,
+      subject: lead.title ? `Re: ${lead.title}` : 'Following up',
+      body: template.replace('{{leadTitle}}', lead.title || ''),
+      isHtml: false
+    });
+
+    await prisma.lead.update({
+      where: { id: leadId },
+      data: { lastFollowUpAt: new Date() }
+    });
+  } catch (err) {
+    logger.error('Failed to send follow-up email', {
+      orgId,
+      leadId,
+      error: err instanceof Error ? err.message : String(err)
+    });
+  }
+}
+
+/**
+ * Handle stage change automation. Sends a quick email acknowledging progress.
+ */
+export async function handleStageChange(orgId: string, leadId: string) {
+  await sendFollowUpEmail(
+    orgId,
+    leadId,
+    'Thanks for the update on {{leadTitle}}. Let me know if you have any questions as we move forward.'
+  );
+}
+
+/**
+ * Check for stagnant leads (updated >7 days ago) and send follow-ups.
+ */
+export async function checkStagnantLeads(orgId: string) {
+  const staleDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  const leads = await prisma.lead.findMany({
+    where: {
+      orgId,
+      status: 'active',
+      automationEnabled: true,
+      updatedAt: { lt: staleDate }
+    }
+  });
+
+  for (const lead of leads) {
+    if (lead.lastFollowUpAt && lead.lastFollowUpAt > staleDate) continue;
+    await sendFollowUpEmail(
+      orgId,
+      lead.id,
+      'Just checking in about {{leadTitle}}. Let me know if you are still interested.'
+    );
+  }
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -288,6 +288,8 @@ model Lead {
   source             String?
   assignedToId       String?
   sourceThreadId     String?
+  automationEnabled  Boolean        @default(false)
+  lastFollowUpAt     DateTime?
   expectedCloseDate  DateTime?
   actualCloseDate    DateTime?
   createdAt          DateTime       @default(now())


### PR DESCRIPTION
## Summary
- add follow-up automation service using Gmail
- track per-lead automation settings
- toggle follow-up automation from pipeline cards

## Testing
- `npm test` *(fails: recursive turbo invocations)*
- `npm run lint` *(fails: recursive turbo invocations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc8bc0988325be8c3c4140dc9c4b