### PR TITLE
feat(theme): expose CSS variables and ThemeProvider

### DIFF
--- a/apps/web/src/components/app/TodayAtAGlance.tsx
+++ b/apps/web/src/components/app/TodayAtAGlance.tsx
@@ -69,7 +69,10 @@ export default function TodayAtAGlance({
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="h-32 bg-slate-200 dark:bg-slate-700 rounded-lg animate-pulse"></div>
+          <div
+            key={i}
+            className="h-32 bg-[var(--color-navy-200)] dark:bg-[var(--color-navy-700)] rounded-[var(--radius-lg)] animate-pulse"
+          ></div>
         ))}
       </div>
     );
@@ -93,10 +96,10 @@ export default function TodayAtAGlance({
             <GlassCardTitle className="text-2xl font-bold mb-1">
               {leadsData?.new || 0}
             </GlassCardTitle>
-            <p className="text-sm text-slate-600 dark:text-slate-400">
+            <p className="text-sm text-[var(--color-navy-600)] dark:text-[var(--color-navy-400)]">
               New leads today
             </p>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-[var(--color-navy-500)] mt-1">
               {leadsData?.total || 0} total active
             </p>
           </div>
@@ -119,10 +122,10 @@ export default function TodayAtAGlance({
             <GlassCardTitle className="text-2xl font-bold mb-1">
               {repliesData?.due || 0}
             </GlassCardTitle>
-            <p className="text-sm text-slate-600 dark:text-slate-400">
+            <p className="text-sm text-[var(--color-navy-600)] dark:text-[var(--color-navy-400)]">
               Replies due today
             </p>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-[var(--color-navy-500)] mt-1">
               {repliesData?.due || 0} pending
             </p>
           </div>
@@ -145,10 +148,10 @@ export default function TodayAtAGlance({
             <GlassCardTitle className="text-2xl font-bold mb-1">
               {meetingsData?.today || 0}
             </GlassCardTitle>
-            <p className="text-sm text-slate-600 dark:text-slate-400">
+            <p className="text-sm text-[var(--color-navy-600)] dark:text-[var(--color-navy-400)]">
               Meetings today
             </p>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-[var(--color-navy-500)] mt-1">
               {meetingsData?.today || 0} scheduled
             </p>
           </div>
@@ -171,10 +174,10 @@ export default function TodayAtAGlance({
             <GlassCardTitle className="text-2xl font-bold mb-1">
               {tokenHealthData?.healthy || 0}/{tokenHealthData?.total || 0}
             </GlassCardTitle>
-            <p className="text-sm text-slate-600 dark:text-slate-400">
+            <p className="text-sm text-[var(--color-navy-600)] dark:text-[var(--color-navy-400)]">
               Token health
             </p>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-[var(--color-navy-500)] mt-1">
               {tokenHealthData?.status || 'unknown'} status
             </p>
           </div>

--- a/apps/web/src/components/providers/ClientProviders.tsx
+++ b/apps/web/src/components/providers/ClientProviders.tsx
@@ -2,6 +2,8 @@
 
 import dynamic from "next/dynamic";
 
+import ThemeProvider from "./ThemeProvider";
+
 const ClientRoot = dynamic(() => import("./ClientRoot"), { ssr: false });
 const SessionProviderWrapper = dynamic(() => import("./SessionProviderWrapper"), { ssr: false });
 const TRPCProvider = dynamic(() => import("./TRPCProvider").then(mod => ({ default: mod.TRPCProvider })), { ssr: false });
@@ -13,13 +15,15 @@ interface ClientProvidersProps {
 export default function ClientProviders({ children }: ClientProvidersProps) {
   return (
     <SessionProviderWrapper>
-      <TRPCProvider>
-        {children}
-        <ClientRoot />
-        <div id="portal-toasts" />
-        <div id="portal-modals" />
-        <div id="portal-drawers" />
-      </TRPCProvider>
+      <ThemeProvider>
+        <TRPCProvider>
+          {children}
+          <ClientRoot />
+          <div id="portal-toasts" />
+          <div id="portal-modals" />
+          <div id="portal-drawers" />
+        </TRPCProvider>
+      </ThemeProvider>
     </SessionProviderWrapper>
   );
 }

--- a/apps/web/src/components/providers/ThemeProvider.tsx
+++ b/apps/web/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect } from "react";
+import { riverCSSVariables } from "@/lib/river-theme";
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export default function ThemeProvider({ children }: ThemeProviderProps) {
+  useEffect(() => {
+    const root = document.documentElement;
+    Object.entries(riverCSSVariables).forEach(([key, value]) => {
+      root.style.setProperty(key, value);
+    });
+  }, []);
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/river/FlowCard.tsx
+++ b/apps/web/src/components/river/FlowCard.tsx
@@ -25,19 +25,19 @@ export default function FlowCard({
     : false;
 
   const variantClasses = {
-    default: 'bg-white dark:bg-slate-800 shadow-sm',
-    elevated: 'bg-white dark:bg-slate-800 shadow-lg',
-    hero: 'bg-gradient-to-br from-white/95 to-slate-50/95 dark:from-slate-800/95 dark:to-slate-900/95 shadow-xl backdrop-blur-sm'
+    default: 'bg-[var(--color-navy-50)] dark:bg-[var(--color-navy-800)] shadow-sm',
+    elevated: 'bg-[var(--color-navy-50)] dark:bg-[var(--color-navy-800)] shadow-lg',
+    hero: 'bg-gradient-to-br from-[var(--color-navy-50)]/95 to-[var(--color-navy-100)]/95 dark:from-[var(--color-navy-800)]/95 dark:to-[var(--color-navy-900)]/95 shadow-xl backdrop-blur-sm'
   };
 
-  const glassyClasses = glassy 
-    ? 'backdrop-blur-md bg-white/80 dark:bg-slate-800/80 border border-white/20'
+  const glassyClasses = glassy
+    ? 'backdrop-blur-md bg-[var(--color-navy-50)]/80 dark:bg-[var(--color-navy-800)]/80 border border-white/20'
     : '';
 
   return (
     <motion.div
       className={cn(
-        'rounded-2xl border border-slate-200 dark:border-slate-700 overflow-hidden',
+        'rounded-[var(--radius-2xl)] border border-[var(--color-navy-200)] dark:border-[var(--color-navy-700)] overflow-hidden',
         variantClasses[variant],
         glassyClasses,
         hoverable && 'cursor-pointer',
@@ -57,7 +57,7 @@ export default function FlowCard({
             }
           : hoverable && !prefersReducedMotion
           ? {
-              borderColor: 'rgb(20, 184, 166)',
+              borderColor: 'var(--color-teal-500)',
               transition: { duration: 0.2 }
             }
           : {}
@@ -84,7 +84,7 @@ export default function FlowCard({
       {/* Flowing border accent */}
       {variant === 'hero' && !prefersReducedMotion && (
         <motion.div
-          className="absolute inset-0 rounded-2xl"
+          className="absolute inset-0 rounded-[var(--radius-2xl)]"
           style={{
             background: 'linear-gradient(90deg, transparent, rgba(20, 184, 166, 0.3), transparent)',
             backgroundSize: '200% 100%'

--- a/apps/web/src/lib/river-theme.ts
+++ b/apps/web/src/lib/river-theme.ts
@@ -168,3 +168,27 @@ export const riverTheme = {
 } as const;
 
 export type RiverTheme = typeof riverTheme;
+
+// Generate CSS variable mappings for theme tokens
+export const riverCSSVariables: Record<string, string> = {
+  // Color variables
+  ...Object.fromEntries(
+    Object.entries(riverColors).flatMap(([color, shades]) =>
+      Object.entries(shades).map(([shade, value]) => [`--color-${color}-${shade}`, value])
+    )
+  ),
+  // Spacing variables
+  ...Object.fromEntries(
+    Object.entries(spacing).map(([key, value]) => [`--space-${key}`, value])
+  ),
+  // Radius variables
+  ...Object.fromEntries(
+    Object.entries(radius).map(([key, value]) => [`--radius-${key}`, value])
+  ),
+  // Typography variables
+  ...Object.fromEntries([
+    ...Object.entries(typography.scale).map(([key, value]) => [`--font-size-${key}`, value]),
+    ...Object.entries(typography.weights).map(([key, value]) => [`--font-weight-${key}`, value]),
+    ...Object.entries(typography.families).map(([key, value]) => [`--font-family-${key}`, value])
+  ])
+};

--- a/docs/theme-tokens.md
+++ b/docs/theme-tokens.md
@@ -1,0 +1,27 @@
+# River Theme Tokens
+
+The River design system exposes CSS variables for colors, spacing, radius and typography.
+
+## Color Variables
+Variables follow the pattern `--color-{palette}-{shade}`.
+
+Example: `--color-navy-900`, `--color-teal-400`.
+
+## Spacing Variables
+Spacing tokens use `--space-{step}` based on an 8px grid.
+
+Example: `--space-4` equals `1rem` (16px).
+
+## Radius Variables
+Border radii are exposed as `--radius-{size}`.
+
+Example: `--radius-2xl`.
+
+## Typography Variables
+Typography variables include font sizes, weights and families.
+
+* `--font-size-base`
+* `--font-weight-semibold`
+* `--font-family-ui`
+
+Use these variables in Tailwind classes with square bracket notation, e.g. `bg-[var(--color-navy-900)]` or `rounded-[var(--radius-2xl)]`.


### PR DESCRIPTION
## Summary
- export River theme tokens as CSS variables
- inject variables at runtime with ThemeProvider
- use theme tokens in dashboard widgets and document available tokens

## Testing
- `npm test` (fails: recursive turborepo invocations)
- `npm run lint` (fails: recursive turborepo invocations)


------
https://chatgpt.com/codex/tasks/task_e_68a4cd64a9448325b3552261a0fc14c5