### PR TITLE
Fetch notifications from API and persist read state

### DIFF
--- a/apps/web/src/app/api/notifications/[id]/read/route.ts
+++ b/apps/web/src/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { notifications } from '../../data';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const notification = notifications.find(n => n.id === params.id);
+  if (notification) {
+    notification.isRead = true;
+  }
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/api/notifications/data.ts
+++ b/apps/web/src/app/api/notifications/data.ts
@@ -1,0 +1,68 @@
+export interface Notification {
+  id: string;
+  type: 'email' | 'meeting' | 'lead' | 'system' | 'integration' | 'task';
+  title: string;
+  message: string;
+  timestamp: string;
+  isRead: boolean;
+  priority: 'low' | 'medium' | 'high';
+  entityId?: string;
+}
+
+export const notifications: Notification[] = [
+  {
+    id: '1',
+    type: 'lead',
+    title: 'New Lead Detected',
+    message: 'Sarah Johnson from TechCorp inquired about enterprise pricing. Lead automatically created.',
+    timestamp: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+    isRead: false,
+    priority: 'high',
+    entityId: 'lead-1'
+  },
+  {
+    id: '2',
+    type: 'email',
+    title: 'Email Integration Connected',
+    message: 'Gmail integration successfully connected. Syncing emails and detecting leads.',
+    timestamp: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    isRead: false,
+    priority: 'medium'
+  },
+  {
+    id: '3',
+    type: 'meeting',
+    title: 'Meeting Scheduled',
+    message: 'Product demo with Acme Corp scheduled for tomorrow at 2:00 PM.',
+    timestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    isRead: true,
+    priority: 'medium'
+  },
+  {
+    id: '4',
+    type: 'system',
+    title: 'System Update',
+    message: 'New features available: AI-powered email drafting and advanced analytics.',
+    timestamp: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    isRead: true,
+    priority: 'low'
+  },
+  {
+    id: '5',
+    type: 'task',
+    title: 'Task Completed',
+    message: 'Follow-up call with John Smith completed successfully.',
+    timestamp: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
+    isRead: true,
+    priority: 'low'
+  },
+  {
+    id: '6',
+    type: 'integration',
+    title: 'Calendar Sync Issue',
+    message: 'Calendar sync temporarily paused. Will resume automatically.',
+    timestamp: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    isRead: false,
+    priority: 'medium'
+  }
+];

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { notifications } from './data';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json(notifications);
+}


### PR DESCRIPTION
## Summary
- Replace mock notifications with `/api/notifications` fetch and dynamic actions for navigation
- Add endpoints for fetching notifications and marking them as read
- Persist read/unread state when notifications or action buttons are used

## Testing
- `npm run lint` *(failed: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm test` *(failed: Playwright Test did not expect test.describe() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cea729348325afe65ce108f2e5cb