### PR TITLE
feat: add AI summaries for key contexts

### DIFF
--- a/apps/web/src/app/api/ai/summary/route.ts
+++ b/apps/web/src/app/api/ai/summary/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+import { auth } from '@/server/auth';
+import { aiService } from '@/server/ai/ai-service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await auth();
+    if (!session) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    const context = req.nextUrl.searchParams.get('context');
+    if (!context || !['pipeline', 'inbox', 'calendar', 'contacts'].includes(context)) {
+      return new Response('Invalid context', { status: 400 });
+    }
+
+    const result = await aiService.sendMessage('Summarize', undefined, { type: context as any });
+
+    return new Response(JSON.stringify({ summary: result.content }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('AI summary API error:', error);
+    return new Response('Failed to generate summary', { status: 500 });
+  }
+}

--- a/apps/web/src/app/app/inbox/page.tsx
+++ b/apps/web/src/app/app/inbox/page.tsx
@@ -13,23 +13,40 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { 
-  Mail, 
-  Filter, 
-  Bookmark, 
-  Search, 
+import {
+  Mail,
+  Filter,
+  Bookmark,
+  Search,
   MoreHorizontal,
   Star,
   Clock,
   AlertTriangle,
   CheckCircle,
-  X
+  X,
+  Sparkles
 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function InboxPage() {
   const [activeTab, setActiveTab] = useState("leads");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
+  const [summary, setSummary] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchSummary = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/ai/summary?context=inbox');
+      const data = await res.json();
+      setSummary(data.summary);
+    } catch (err) {
+      setSummary('Failed to generate summary');
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const tabOptions = [
     { value: "leads", label: "Leads", count: 24, icon: <Star className="h-3 w-3" /> },
@@ -87,30 +104,35 @@ export default function InboxPage() {
               </div>
             </div>
 
-            {/* Saved Filters Dropdown */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="sm" className="flex items-center gap-2">
-                  <Filter className="h-4 w-4" />
-                  Saved Filters
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuLabel>Saved Filters</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {savedFilters.map((filter) => (
-                  <DropdownMenuItem 
-                    key={filter.id}
-                    onClick={() => setSelectedFilter(filter.id)}
-                    className="flex items-center gap-2"
-                  >
-                    {filter.icon}
-                    {filter.label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          {/* Saved Filters Dropdown */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" className="flex items-center gap-2">
+                <Filter className="h-4 w-4" />
+                Saved Filters
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel>Saved Filters</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {savedFilters.map((filter) => (
+                <DropdownMenuItem
+                  key={filter.id}
+                  onClick={() => setSelectedFilter(filter.id)}
+                  className="flex items-center gap-2"
+                >
+                  {filter.icon}
+                  {filter.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <Button variant="outline" size="sm" onClick={fetchSummary} disabled={loading}>
+            <Sparkles className="h-4 w-4 mr-2" />
+            {loading ? 'Summarizing...' : 'AI Summary'}
+          </Button>
+        </div>
 
           {/* Quick Filters */}
           <div className="flex items-center gap-2 mt-3">
@@ -132,8 +154,18 @@ export default function InboxPage() {
 
         {/* Enhanced Inbox Component */}
         <div className="px-6 pb-8">
-          <EnhancedInbox 
-            activeTab={activeTab} 
+          {summary && (
+            <Card className="mb-4">
+              <CardHeader>
+                <CardTitle className="text-sm">AI Summary</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm whitespace-pre-line">{summary}</p>
+              </CardContent>
+            </Card>
+          )}
+          <EnhancedInbox
+            activeTab={activeTab}
             searchQuery={searchQuery}
             selectedFilter={selectedFilter}
           />

--- a/apps/web/src/app/app/pipeline/page.tsx
+++ b/apps/web/src/app/app/pipeline/page.tsx
@@ -3,25 +3,42 @@ import AppShell from "@/components/app/AppShell";
 import EnhancedPipelineBoard from "@/components/pipeline/EnhancedPipelineBoard";
 import Toolbar, { ToolbarGroup, ToolbarItem } from "@/components/app/Toolbar";
 import { Button } from "@/components/ui/button";
-import { 
-  Briefcase, 
-  Search, 
-  Filter, 
-  Group, 
-  Plus, 
+import {
+  Briefcase,
+  Search,
+  Filter,
+  Group,
+  Plus,
   Download,
   Upload,
   Settings,
   BarChart3,
   Calendar,
   DollarSign,
-  User
+  User,
+  Sparkles
 } from "lucide-react";
 import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default function PipelinePage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [groupBy, setGroupBy] = useState("stage");
+  const [summary, setSummary] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchSummary = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/ai/summary?context=pipeline');
+      const data = await res.json();
+      setSummary(data.summary);
+    } catch (err) {
+      setSummary('Failed to generate summary');
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const quickFilters = [
     { label: "High Value", count: 12, active: false },
@@ -77,19 +94,26 @@ export default function PipelinePage() {
               {/* Right Group - Actions */}
               <ToolbarGroup>
                 <ToolbarItem>
+                  <Button variant="outline" size="sm" onClick={fetchSummary} disabled={loading}>
+                    <Sparkles className="h-4 w-4 mr-2" />
+                    {loading ? 'Summarizing...' : 'AI Summary'}
+                  </Button>
+                </ToolbarItem>
+
+                <ToolbarItem>
                   <Button variant="outline" size="sm">
                     <Download className="h-4 w-4 mr-2" />
                     Export
                   </Button>
                 </ToolbarItem>
-                
+
                 <ToolbarItem>
                   <Button variant="outline" size="sm">
                     <Upload className="h-4 w-4 mr-2" />
                     Import
                   </Button>
                 </ToolbarItem>
-                
+
                 <ToolbarItem>
                   <Button variant="outline" size="sm">
                     <Settings className="h-4 w-4" />
@@ -119,10 +143,17 @@ export default function PipelinePage() {
 
         {/* Enhanced Pipeline Board */}
         <div className="px-6 pb-8">
-          <EnhancedPipelineBoard 
-            searchQuery={searchQuery}
-            groupBy={groupBy}
-          />
+          {summary && (
+            <Card className="mb-4">
+              <CardHeader>
+                <CardTitle className="text-sm">AI Summary</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm whitespace-pre-line">{summary}</p>
+              </CardContent>
+            </Card>
+          )}
+          <EnhancedPipelineBoard searchQuery={searchQuery} groupBy={groupBy} />
         </div>
       </AppShell>
     </div>


### PR DESCRIPTION
## Summary
- extend AI context gathering for pipeline, inbox, calendar and contacts
- add `/api/ai/summary` endpoint returning summaries for these contexts
- surface AI Summary buttons on pipeline and inbox pages

## Testing
- `npm test` *(fails: recursive turbo invocations)*
- `npm run lint` *(fails: recursive turbo invocations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cea716e08325989d3202063c7600