### PR TITLE
Add quick filter state and tests

### DIFF
--- a/apps/web/src/app/app/inbox/__tests__/page.test.tsx
+++ b/apps/web/src/app/app/inbox/__tests__/page.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InboxPage from '../page';
+
+vi.mock('@/components/app/AppShell', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/inbox/EnhancedInbox', () => ({
+  default: ({ selectedFilter }: { selectedFilter: string }) => (
+    <div data-testid="filter">{selectedFilter}</div>
+  ),
+}));
+
+describe('InboxPage quick filters', () => {
+  it('applies and resets filters', async () => {
+    const user = userEvent.setup();
+    render(<InboxPage />);
+
+    const output = () => screen.getByTestId('filter').textContent;
+    expect(output()).toBe('');
+
+    const unread = screen.getByRole('button', { name: /Unread/i });
+    await user.click(unread);
+    expect(output()).toBe('Unread');
+
+    await user.click(unread);
+    expect(output()).toBe('');
+  });
+});
+

--- a/apps/web/src/app/app/inbox/page.tsx
+++ b/apps/web/src/app/app/inbox/page.tsx
@@ -30,6 +30,12 @@ export default function InboxPage() {
   const [activeTab, setActiveTab] = useState("leads");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
+  const [quickFilters, setQuickFilters] = useState([
+    { label: "Unread", count: 24, active: false },
+    { label: "High Priority", count: 8, active: false },
+    { label: "This Week", count: 45, active: false },
+    { label: "Overdue", count: 3, active: false }
+  ]);
 
   const tabOptions = [
     { value: "leads", label: "Leads", count: 24, icon: <Star className="h-3 w-3" /> },
@@ -44,12 +50,16 @@ export default function InboxPage() {
     { id: "meeting-requests", label: "Meeting Requests", icon: <CheckCircle className="h-3 w-3" /> }
   ];
 
-  const quickFilters = [
-    { label: "Unread", count: 24, active: false },
-    { label: "High Priority", count: 8, active: false },
-    { label: "This Week", count: 45, active: false },
-    { label: "Overdue", count: 3, active: false }
-  ];
+  const handleQuickFilter = (label: string) => {
+    setQuickFilters((prev) =>
+      prev.map((filter) =>
+        filter.label === label
+          ? { ...filter, active: !filter.active }
+          : { ...filter, active: false }
+      )
+    );
+    setSelectedFilter((current) => (current === label ? null : label));
+  };
 
   return (
     <div className="relative min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
@@ -99,9 +109,14 @@ export default function InboxPage() {
                 <DropdownMenuLabel>Saved Filters</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 {savedFilters.map((filter) => (
-                  <DropdownMenuItem 
+                  <DropdownMenuItem
                     key={filter.id}
-                    onClick={() => setSelectedFilter(filter.id)}
+                    onClick={() => {
+                      setSelectedFilter(filter.id);
+                      setQuickFilters((prev) =>
+                        prev.map((f) => ({ ...f, active: false }))
+                      );
+                    }}
                     className="flex items-center gap-2"
                   >
                     {filter.icon}
@@ -120,7 +135,7 @@ export default function InboxPage() {
                 key={index}
                 variant={filter.active ? "default" : "outline"}
                 size="sm"
-                onClick={() => console.log(`Apply filter: ${filter.label}`)}
+                onClick={() => handleQuickFilter(filter.label)}
                 className="text-xs h-7"
               >
                 {filter.label}
@@ -132,10 +147,10 @@ export default function InboxPage() {
 
         {/* Enhanced Inbox Component */}
         <div className="px-6 pb-8">
-          <EnhancedInbox 
-            activeTab={activeTab} 
+          <EnhancedInbox
+            activeTab={activeTab}
             searchQuery={searchQuery}
-            selectedFilter={selectedFilter}
+            selectedFilter={selectedFilter || ""}
           />
         </div>
       </AppShell>

--- a/apps/web/src/app/app/pipeline/__tests__/page.test.tsx
+++ b/apps/web/src/app/app/pipeline/__tests__/page.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PipelinePage from '../page';
+
+vi.mock('@/components/app/AppShell', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/pipeline/EnhancedPipelineBoard', () => ({
+  default: ({ selectedFilters }: { selectedFilters: string[] }) => (
+    <div data-testid="filters">{JSON.stringify(selectedFilters)}</div>
+  ),
+}));
+
+describe('PipelinePage quick filters', () => {
+  it('applies and resets filters', async () => {
+    const user = userEvent.setup();
+    render(<PipelinePage />);
+
+    const output = () => screen.getByTestId('filters').textContent;
+
+    expect(output()).toBe('[]');
+
+    const highValue = screen.getByRole('button', { name: /High Value/i });
+    await user.click(highValue);
+    expect(output()).toBe(JSON.stringify(['High Value']));
+
+    const overdue = screen.getByRole('button', { name: /Overdue/i });
+    await user.click(overdue);
+    expect(output()).toBe(JSON.stringify(['High Value', 'Overdue']));
+
+    await user.click(highValue);
+    expect(output()).toBe(JSON.stringify(['Overdue']));
+  });
+});
+

--- a/apps/web/src/app/app/pipeline/page.tsx
+++ b/apps/web/src/app/app/pipeline/page.tsx
@@ -23,12 +23,24 @@ export default function PipelinePage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [groupBy, setGroupBy] = useState("stage");
 
-  const quickFilters = [
+  const [quickFilters, setQuickFilters] = useState([
     { label: "High Value", count: 12, active: false },
     { label: "Overdue", count: 3, active: false },
     { label: "This Week", count: 8, active: false },
     { label: "Hot Leads", count: 5, active: false }
-  ];
+  ]);
+
+  const toggleFilter = (label: string) => {
+    setQuickFilters((prev) =>
+      prev.map((filter) =>
+        filter.label === label ? { ...filter, active: !filter.active } : filter
+      )
+    );
+  };
+
+  const activeFilters = quickFilters
+    .filter((filter) => filter.active)
+    .map((filter) => filter.label);
 
   const groupByOptions = [
     { value: "stage", label: "Stage", icon: <BarChart3 className="h-4 w-4" /> },
@@ -106,7 +118,7 @@ export default function PipelinePage() {
                   key={index}
                   variant={filter.active ? "default" : "outline"}
                   size="sm"
-                  onClick={() => console.log(`Apply filter: ${filter.label}`)}
+                  onClick={() => toggleFilter(filter.label)}
                   className="text-xs h-7"
                 >
                   {filter.label}
@@ -119,9 +131,9 @@ export default function PipelinePage() {
 
         {/* Enhanced Pipeline Board */}
         <div className="px-6 pb-8">
-          <EnhancedPipelineBoard 
+          <EnhancedPipelineBoard
             searchQuery={searchQuery}
-            groupBy={groupBy}
+            selectedFilters={activeFilters}
           />
         </div>
       </AppShell>


### PR DESCRIPTION
## Summary
- add stateful quick filters to pipeline page and pass to board
- convert inbox quick filters to state and forward to inbox component
- cover filter toggle and reset behavior with tests

## Testing
- `npx vitest run src/app/app/pipeline/__tests__/page.test.tsx src/app/app/inbox/__tests__/page.test.tsx` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a4cea730e08325918ea0a5bb0764c5