### PR TITLE
refactor: centralize logging and audit forwarding

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -20,6 +20,9 @@ const nextConfig = {
   experimental: {
     externalDir: true,
   },
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production'
+  },
   outputFileTracingIncludes: {
     '/*': [
       './node_modules/.prisma/client/**',

--- a/apps/web/src/app/api/dashboard/route.ts
+++ b/apps/web/src/app/api/dashboard/route.ts
@@ -23,17 +23,12 @@ export async function GET(_req: NextRequest) {
     // Log dashboard access
     logger.userAction('dashboard_access', userEmail || 'unknown', orgId || 'unknown');
 
-    console.log('=== DASHBOARD DEBUG START ===');
-    console.log('orgId:', orgId);
-    console.log('userEmail:', userEmail);
-
     // Fetch real email data
     let unreadCount = 0;
     let recentThreads: any[] = [];
     
     if (orgId) {
       try {
-        console.log('Fetching email data for orgId:', orgId);
         
         // Get unread count
         unreadCount = await prisma.emailMessage.count({
@@ -41,13 +36,11 @@ export async function GET(_req: NextRequest) {
             orgId
           }
         });
-        console.log('Unread count:', unreadCount);
 
         // Check total threads first
         const totalThreads = await prisma.emailThread.count({
           where: { orgId }
         });
-        console.log('Total threads in database:', totalThreads);
 
         // Get recent threads with decrypted data
         const threads = await prisma.emailThread.findMany({
@@ -60,8 +53,6 @@ export async function GET(_req: NextRequest) {
           orderBy: { updatedAt: 'desc' },
           take: 20
         });
-        console.log('Found threads:', threads.length);
-        console.log('First thread sample:', threads[0] ? {
           id: threads[0].id,
           subjectEnc: !!threads[0].subjectEnc,
           participantsEnc: !!threads[0].participantsEnc,
@@ -119,14 +110,12 @@ export async function GET(_req: NextRequest) {
             };
           }
         }));
-        console.log('Processed threads:', recentThreads.length);
       } catch (error) {
         console.error('Failed to fetch email data:', error);
         unreadCount = 0;
         recentThreads = [];
       }
     } else {
-      console.log('No orgId found for user:', userEmail);
     }
 
     // Fetch calendar data
@@ -143,7 +132,6 @@ export async function GET(_req: NextRequest) {
         const totalEvents = await prisma.calendarEvent.count({
           where: { orgId }
         });
-        console.log('Total calendar events in database:', totalEvents);
 
         // Get today's events
         const todayEvents = await prisma.calendarEvent.count({
@@ -192,9 +180,6 @@ export async function GET(_req: NextRequest) {
             take: 10
           });
         }
-
-        console.log('Found upcoming events:', events.length);
-        console.log('First event sample:', events[0] ? {
           id: events[0].id,
           titleEnc: !!events[0].titleEnc,
           locationEnc: !!events[0].locationEnc,
@@ -251,9 +236,6 @@ export async function GET(_req: NextRequest) {
           todayCount: todayEvents,
           upcomingCount: upcomingEventsCount
         };
-
-        console.log('Calendar stats:', calendarStats);
-        console.log('Upcoming events:', upcomingEvents.length);
       } catch (error) {
         console.error('Failed to fetch calendar data:', error);
         upcomingEvents = [];
@@ -276,15 +258,10 @@ export async function GET(_req: NextRequest) {
           where: { orgId, status: 'connected' }
         });
         hasCalendarAccounts = calendarAccounts > 0;
-        
-        console.log('Connected email accounts:', emailAccounts);
-        console.log('Connected calendar accounts:', calendarAccounts);
       } catch (error) {
         console.error('Failed to check accounts:', error);
       }
     }
-
-    console.log('=== DASHBOARD DEBUG END ===');
 
     // Return data with real information
     return Response.json({

--- a/apps/web/src/app/api/debug/bypass-kms-sync/route.ts
+++ b/apps/web/src/app/api/debug/bypass-kms-sync/route.ts
@@ -340,7 +340,8 @@ async function processMessage(gmail: any, orgId: string, emailAccountId: string,
     });
 
     // Log the message details for debugging
-    console.log(`Processed message: ${subject}`, {
+    logger.info('Processed message', {
+      subject,
       from,
       to,
       hasHtmlBody: !!htmlBody,

--- a/apps/web/src/app/api/debug/create-oauth-account/route.ts
+++ b/apps/web/src/app/api/debug/create-oauth-account/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/server/auth";
 import { prisma } from "@/server/db";
+import { logger } from "@/lib/logger";
 
 /**
  * Debug endpoint to manually create OAuthAccount record for JWT strategy
@@ -35,8 +36,8 @@ export async function POST(req: NextRequest) {
 
     const emailAccount = user.emailAccounts[0]; // Get first account (Google)
     
-    console.log('🔧 Creating OAuthAccount for background workers', {
-      userEmail: session.user.email,
+    logger.info('Creating OAuthAccount for background workers', {
+      userId: session.user.email,
       provider: emailAccount.provider,
       timestamp: new Date().toISOString()
     });

--- a/apps/web/src/app/api/debug/force-onboarding/route.ts
+++ b/apps/web/src/app/api/debug/force-onboarding/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/server/auth";
 import { handleOAuthCallback, type OAuthCallbackData } from "@/server/onboarding";
+import { logger } from "@/lib/logger";
 
 /**
  * Debug endpoint to manually trigger OAuth onboarding
@@ -22,8 +23,8 @@ export async function POST(req: NextRequest) {
     const body = await req.json().catch(() => ({}));
     const provider = body.provider || 'google';
     
-    console.log('🔧 Force onboarding triggered', {
-      userEmail: session.user.email,
+    logger.info('Force onboarding triggered', {
+      userId: session.user.email,
       provider,
       timestamp: new Date().toISOString()
     });

--- a/apps/web/src/app/api/debug/redis-test/route.ts
+++ b/apps/web/src/app/api/debug/redis-test/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/server/auth';
 import Redis from 'ioredis';
+import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -20,7 +21,7 @@ export async function GET(req: NextRequest) {
 
     // Test Redis connection
     const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
-    console.log('Testing Redis connection to:', redisUrl);
+    logger.info('Testing Redis connection', { redisUrl });
 
     const redis = new Redis(redisUrl, {
       connectTimeout: 5000,

--- a/apps/web/src/app/api/debug/test-token-decryption/route.ts
+++ b/apps/web/src/app/api/debug/test-token-decryption/route.ts
@@ -26,13 +26,15 @@ export async function GET(req: NextRequest) {
     // Try to get orgId from database if not in session
     let orgId = session.user.orgId;
     if (!orgId) {
-      console.log('No orgId in session, looking up from database for:', session.user.email);
+      logger.info('No orgId in session, looking up from database', {
+        userId: session.user.email
+      });
       const org = await prisma.org.findFirst({ 
         where: { name: session.user.email } 
       });
       if (org) {
         orgId = org.id;
-        console.log('Found orgId from database:', orgId);
+        logger.info('Found orgId from database', { orgId });
       } else {
         return NextResponse.json({
           success: false,

--- a/apps/web/src/app/api/debug/trigger-sync/route.ts
+++ b/apps/web/src/app/api/debug/trigger-sync/route.ts
@@ -36,7 +36,10 @@ export async function POST(req: NextRequest) {
     const syncJobs = [];
     for (const account of emailAccounts) {
       try {
-        console.log(`Triggering sync for account: ${account.id} (${account.email})`);
+        logger.info('Triggering sync for account', {
+          accountId: account.id,
+          emailAddress: account.email
+        });
         await enqueueEmailBackfill(orgId, account.id, 30); // Sync last 30 days
         syncJobs.push({
           accountId: account.id,

--- a/apps/web/src/app/api/organization/invites/route.ts
+++ b/apps/web/src/app/api/organization/invites/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { auth } from '@/server/auth';
 import { prisma } from '@/server/db';
+import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -100,7 +101,11 @@ export async function POST(request: NextRequest) {
     // 3. Generate a unique invite link
 
     // For now, we'll just return success
-    console.log('Invitation would be sent to:', email, 'for role:', role, 'in org:', org.org.id);
+    logger.info('Invitation placeholder', {
+      emailAddress: email,
+      role,
+      orgId: org.org.id
+    });
 
     return Response.json({ 
       success: true, 

--- a/apps/web/src/app/api/user/appearance/route.ts
+++ b/apps/web/src/app/api/user/appearance/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { auth } from '@/server/auth';
+import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -50,7 +51,10 @@ export async function PUT(request: NextRequest) {
 
     // In a real implementation, you'd store these preferences in the database
     // For now, we'll just return success
-    console.log('Appearance preferences updated for user:', session.user.email, preferences);
+    logger.info('Appearance preferences updated', {
+      userId: session.user.email,
+      preferences
+    });
 
     return Response.json({ success: true, preferences });
   } catch (error) {

--- a/apps/web/src/app/api/user/notifications/route.ts
+++ b/apps/web/src/app/api/user/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { auth } from '@/server/auth';
 import { prisma } from '@/server/db';
+import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -53,7 +54,10 @@ export async function PUT(request: NextRequest) {
 
     // In a real implementation, you'd store these preferences in the database
     // For now, we'll just return success
-    console.log('Notification preferences updated for user:', session.user.email, preferences);
+    logger.info('Notification preferences updated', {
+      userId: session.user.email,
+      preferences
+    });
 
     return Response.json({ success: true, preferences });
   } catch (error) {

--- a/apps/web/src/components/app/ActivityFeed.tsx
+++ b/apps/web/src/components/app/ActivityFeed.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { GlassCard, GlassCardContent, GlassCardHeader, GlassCardTitle } from '@/components/ui/glass-card';
+import { logger } from '@/lib/logger';
 import { 
   Activity, 
   Mail, 
@@ -50,7 +51,7 @@ export default function ActivityFeed({ className = '' }: ActivityFeedProps) {
         status: 'urgent',
         action: {
           label: 'Review',
-          onClick: () => console.log('Review lead')
+          onClick: () => logger.info('Activity action', { action: 'review-lead' })
         }
       },
       {
@@ -62,7 +63,7 @@ export default function ActivityFeed({ className = '' }: ActivityFeedProps) {
         status: 'pending',
         action: {
           label: 'View',
-          onClick: () => console.log('View meeting')
+          onClick: () => logger.info('Activity action', { action: 'view-meeting' })
         }
       },
       {
@@ -82,7 +83,7 @@ export default function ActivityFeed({ className = '' }: ActivityFeedProps) {
         status: 'completed',
         action: {
           label: 'Review',
-          onClick: () => console.log('Review response')
+          onClick: () => logger.info('Activity action', { action: 'review-response' })
         }
       },
       {

--- a/apps/web/src/components/app/ConnectedAccountsPanel.tsx
+++ b/apps/web/src/components/app/ConnectedAccountsPanel.tsx
@@ -6,6 +6,7 @@ import { CheckCircle, AlertCircle, RefreshCw, Mail, Calendar, X, Plus } from "lu
 import { signIn, signOut } from "next-auth/react";
 import { useState } from "react";
 import { TokenHealth } from "@/server/oauth";
+import { logger } from "@/lib/logger";
 
 interface ConnectedAccountsPanelProps {
   tokenHealth: TokenHealth[];
@@ -113,8 +114,8 @@ export default function ConnectedAccountsPanel({
     return false;
   };
 
-  // Debug logging for integration detection
-  console.log('ConnectedAccountsPanel debug:', {
+  // Structured logging for integration detection
+  logger.info('ConnectedAccountsPanel debug', {
     tokenHealthCount: tokenHealth?.length || 0,
     tokenHealth: tokenHealth?.map(t => ({
       provider: t.provider,
@@ -128,7 +129,7 @@ export default function ConnectedAccountsPanel({
   const googleAccount = connectedAccounts.find(t => t.provider === 'google');
   const microsoftAccount = connectedAccounts.find(t => t.provider === 'azure-ad');
 
-  console.log('ConnectedAccountsPanel accounts:', {
+  logger.info('ConnectedAccountsPanel accounts', {
     connectedCount: connectedAccounts.length,
     hasGoogle: !!googleAccount,
     hasMicrosoft: !!microsoftAccount,

--- a/apps/web/src/components/app/DashboardContent.tsx
+++ b/apps/web/src/components/app/DashboardContent.tsx
@@ -12,6 +12,7 @@ import CommandPalette from '../common/CommandPalette';
 import { CurvedDivider } from '@/components/ui/curved-divider';
 import { Button } from '@/components/ui/button';
 import { Search, Plus, Calendar, Mail, MessageSquare } from 'lucide-react';
+import { logger } from '@/lib/logger';
 
 interface DashboardContentProps {
   className?: string;
@@ -132,10 +133,10 @@ export default function DashboardContent({ className = '' }: DashboardContentPro
             {integrationsLoading ? (
               <div className="h-48 bg-slate-200 dark:bg-slate-700 rounded animate-pulse"></div>
             ) : (
-              <HealthWidget 
-                integrations={integrationsData?.emailAccounts || []} 
-                onFix={(id) => console.log('Fix integration:', id)} 
-                onReauth={(id) => console.log('Reauth integration:', id)} 
+              <HealthWidget
+                integrations={integrationsData?.emailAccounts || []}
+                onFix={(id) => logger.info('Dashboard integration action', { action: 'fix', id })}
+                onReauth={(id) => logger.info('Dashboard integration action', { action: 'reauth', id })}
               />
             )}
             

--- a/apps/web/src/components/app/FirstRunOnboarding.tsx
+++ b/apps/web/src/components/app/FirstRunOnboarding.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Mail, Calendar, ArrowRight, CheckCircle } from "lucide-react";
 import { signIn, signOut } from "next-auth/react";
 import { useState } from "react";
+import { logger } from "@/lib/logger";
 
 interface FirstRunOnboardingProps {
   hasEmailIntegration: boolean;
@@ -21,7 +22,7 @@ export default function FirstRunOnboarding({
     try {
       // Force re-authentication to ensure we get the full scopes
       // by temporarily signing out and then signing back in
-      console.log(`Forcing re-authentication for ${provider} to upgrade scopes`);
+      logger.info('Forcing re-authentication to upgrade scopes', { provider });
       
       // Store the current provider in localStorage to handle the re-auth flow
       localStorage.setItem('pendingOAuthUpgrade', provider);

--- a/apps/web/src/components/app/HealthWidget.tsx
+++ b/apps/web/src/components/app/HealthWidget.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
 import { CheckCircle, AlertTriangle, XCircle, RefreshCw, Wifi, WifiOff, Settings, Clock, Zap, Mail, Calendar } from 'lucide-react';
+import { logger } from '@/lib/logger';
 
 interface Integration {
   id: string;
@@ -189,7 +190,7 @@ export default function HealthWidget({ integrations = [], onFix, onReauth }: Hea
                <div className="flex flex-col gap-2">
                  <Button
                    size="sm"
-                   onClick={() => console.log('Connect Gmail')}
+                  onClick={() => logger.info('Health widget action', { action: 'connect-gmail' })}
                    className="w-full bg-gradient-to-r from-blue-500 to-cyan-500 hover:from-blue-600 hover:to-cyan-600 text-white"
                  >
                    <Mail className="h-4 w-4 mr-2" />
@@ -198,7 +199,7 @@ export default function HealthWidget({ integrations = [], onFix, onReauth }: Hea
                  <Button
                    variant="outline"
                    size="sm"
-                   onClick={() => console.log('Connect Calendar')}
+                  onClick={() => logger.info('Health widget action', { action: 'connect-calendar' })}
                    className="w-full"
                  >
                    <Calendar className="h-4 w-4 mr-2" />

--- a/apps/web/src/components/app/NotificationsPanel.tsx
+++ b/apps/web/src/components/app/NotificationsPanel.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { logger } from '@/lib/logger';
 import { 
   Bell, 
   X, 
@@ -56,7 +57,7 @@ export default function NotificationsPanel({ isOpen, onClose }: NotificationsPan
         priority: 'high',
         action: {
           label: 'View Lead',
-          onClick: () => console.log('View lead')
+          onClick: () => logger.info('Notification action', { action: 'view-lead' })
         }
       },
       {
@@ -69,7 +70,7 @@ export default function NotificationsPanel({ isOpen, onClose }: NotificationsPan
         priority: 'medium',
         action: {
           label: 'View Settings',
-          onClick: () => console.log('View settings')
+          onClick: () => logger.info('Notification action', { action: 'view-settings' })
         }
       },
       {
@@ -82,7 +83,7 @@ export default function NotificationsPanel({ isOpen, onClose }: NotificationsPan
         priority: 'medium',
         action: {
           label: 'View Calendar',
-          onClick: () => console.log('View calendar')
+          onClick: () => logger.info('Notification action', { action: 'view-calendar' })
         }
       },
       {
@@ -113,7 +114,7 @@ export default function NotificationsPanel({ isOpen, onClose }: NotificationsPan
         priority: 'medium',
         action: {
           label: 'Fix Now',
-          onClick: () => console.log('Fix integration')
+          onClick: () => logger.info('Notification action', { action: 'fix-integration' })
         }
       }
     ];

--- a/apps/web/src/components/app/QuickActions.tsx
+++ b/apps/web/src/components/app/QuickActions.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { logger } from '@/lib/logger';
 import { 
   Mail, 
   Calendar, 
@@ -37,7 +38,7 @@ export default function QuickActions({ className = '' }: QuickActionsProps) {
       id: 'compose-email',
       label: 'Compose Email',
       icon: <Mail className="h-4 w-4" />,
-      onClick: () => console.log('Compose email'),
+      onClick: () => logger.info('Quick action', { action: 'compose-email' }),
       color: 'blue',
       shortcut: '⌘E'
     },
@@ -45,7 +46,7 @@ export default function QuickActions({ className = '' }: QuickActionsProps) {
       id: 'schedule-meeting',
       label: 'Schedule Meeting',
       icon: <Calendar className="h-4 w-4" />,
-      onClick: () => console.log('Schedule meeting'),
+      onClick: () => logger.info('Quick action', { action: 'schedule-meeting' }),
       color: 'green',
       shortcut: '⌘M'
     },
@@ -53,7 +54,7 @@ export default function QuickActions({ className = '' }: QuickActionsProps) {
       id: 'add-lead',
       label: 'Add Lead',
       icon: <UserPlus className="h-4 w-4" />,
-      onClick: () => console.log('Add lead'),
+      onClick: () => logger.info('Quick action', { action: 'add-lead' }),
       color: 'purple',
       shortcut: '⌘L'
     },
@@ -61,7 +62,7 @@ export default function QuickActions({ className = '' }: QuickActionsProps) {
       id: 'start-chat',
       label: 'Start Chat',
       icon: <MessageSquare className="h-4 w-4" />,
-      onClick: () => console.log('Start chat'),
+      onClick: () => logger.info('Quick action', { action: 'start-chat' }),
       color: 'teal',
       shortcut: '⌘C'
     },
@@ -69,7 +70,7 @@ export default function QuickActions({ className = '' }: QuickActionsProps) {
       id: 'create-note',
       label: 'Create Note',
       icon: <FileText className="h-4 w-4" />,
-      onClick: () => console.log('Create note'),
+      onClick: () => logger.info('Quick action', { action: 'create-note' }),
       color: 'orange',
       shortcut: '⌘N'
     }

--- a/apps/web/src/components/app/QuickActionsMenu.tsx
+++ b/apps/web/src/components/app/QuickActionsMenu.tsx
@@ -5,12 +5,12 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { 
-  Search, 
-  Plus, 
-  Mail, 
-  Calendar, 
-  UserPlus, 
+import {
+  Search,
+  Plus,
+  Mail,
+  Calendar,
+  UserPlus,
   MessageSquare,
   Settings,
   Zap,
@@ -21,6 +21,7 @@ import {
   Star,
   ArrowRight
 } from 'lucide-react';
+import { logger } from '@/lib/logger';
 
 interface QuickAction {
   id: string;
@@ -77,7 +78,7 @@ export default function QuickActionsMenu({ isOpen, onClose }: QuickActionsMenuPr
       icon: <Clock className="h-4 w-4" />,
       shortcut: '⌘T',
       category: 'create',
-      action: () => console.log('Create task')
+      action: () => logger.info('Quick menu action', { action: 'create-task' })
     },
 
     // Navigate Actions
@@ -153,7 +154,7 @@ export default function QuickActionsMenu({ isOpen, onClose }: QuickActionsMenuPr
       icon: <MessageSquare className="h-4 w-4" />,
       shortcut: '⌘H',
       category: 'tools',
-      action: () => console.log('Open chat assistant')
+      action: () => logger.info('Quick menu action', { action: 'open-chat-assistant' })
     }
   ];
 

--- a/docs/logging-policy.md
+++ b/docs/logging-policy.md
@@ -1,0 +1,15 @@
+# Logging Policy
+
+Rivor uses a structured logger (`apps/web/src/lib/logger.ts`) to record audit events while protecting sensitive data. The logger automatically redacts common secrets and hashes email addresses before emitting entries.
+
+## Audit Forwarding
+
+When the `AUDIT_LOG_URL` environment variable is set, the logger forwards each entry to the configured endpoint. The remote store is responsible for enforcing retention policies and centralized analysis. Forwarding only occurs on the server to avoid exposing credentials in the browser.
+
+## Debug Statements
+
+Local development uses `console` output for readability, but production builds strip remaining `console.*` calls. This is enforced via `next.config.mjs` (`compiler.removeConsole`) so no stray debug statements appear in production bundles.
+
+## Usage
+
+Replace any direct `console.log` calls with `logger.info` or `logger.error` and provide context objects instead of raw sensitive values. The logger redacts or hashes fields such as tokens and email addresses automatically.


### PR DESCRIPTION
## Summary
- replace debug console statements with structured logger usage
- forward audit log entries to a central store
- remove console calls from production builds and document logging policy

## Testing
- `npm test` *(fails: recursive_turbo_invocations)*
- `npm run lint` *(fails: recursive_turbo_invocations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cf6d91b083258abce7a788387430