### PR TITLE
feat: wire pipeline and inbox filters

### DIFF
--- a/apps/web/src/app/app/inbox/__tests__/filters.test.tsx
+++ b/apps/web/src/app/app/inbox/__tests__/filters.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import InboxPage from '../page'
+import React from 'react'
+
+vi.mock('@/components/app/AppShell', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: { div: (props: any) => <div {...props} /> },
+  AnimatePresence: ({ children }: any) => <div>{children}</div>
+}))
+
+describe('InboxPage filters', () => {
+  beforeEach(() => {
+    const threadsByFilter: Record<string, string> = {
+      default: 'Default Thread',
+      unread: 'Unread Thread',
+      'high-priority': 'High Priority Thread',
+      'this-week': 'This Week Thread',
+      overdue: 'Overdue Thread'
+    }
+
+    global.fetch = vi.fn((url: any) => {
+      if (typeof url === 'string' && url.includes('/api/inbox/stats')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            tabs: { leads: 1, review: 1, other: 1 },
+            quickFilters: {
+              unread: 1,
+              highPriority: 1,
+              thisWeek: 1,
+              overdue: 1
+            }
+          })
+        })
+      }
+      if (typeof url === 'string' && url.includes('/api/inbox/threads')) {
+        const params = new URL(url, 'http://localhost').searchParams
+        const filters = params.getAll('filter')
+        const filter = filters[filters.length - 1] || 'default'
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            threads: [
+              {
+                id: '1',
+                subject: threadsByFilter[filter],
+                snippet: '',
+                participants: [{ name: 'A', email: 'a@example.com' }],
+                messageCount: 1,
+                unread: false,
+                starred: false,
+                hasAttachments: false,
+                labels: [],
+                lastMessageAt: '2024-01-01',
+                updatedAt: '2024-01-01'
+              }
+            ]
+          })
+        })
+      }
+      return Promise.reject(new Error('Unknown endpoint'))
+    }) as any
+  })
+
+  it('updates displayed threads when quick filters are selected', async () => {
+    render(<InboxPage />)
+
+    await screen.findByText('Default Thread')
+
+    const filters = [
+      { id: 'unread', label: 'Unread', result: 'Unread Thread' },
+      { id: 'high-priority', label: 'High Priority', result: 'High Priority Thread' },
+      { id: 'this-week', label: 'This Week', result: 'This Week Thread' },
+      { id: 'overdue', label: 'Overdue', result: 'Overdue Thread' }
+    ]
+
+    for (const f of filters) {
+      fireEvent.click(screen.getByText(f.label))
+      await waitFor(() => expect(screen.getByText(f.result)).toBeInTheDocument())
+    }
+  })
+})

--- a/apps/web/src/app/app/pipeline/__tests__/filters.test.tsx
+++ b/apps/web/src/app/app/pipeline/__tests__/filters.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import PipelinePage from '../page'
+import React from 'react'
+
+vi.mock('@/components/app/AppShell', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: { div: (props: any) => <div {...props} /> },
+  AnimatePresence: ({ children }: any) => <div>{children}</div>
+}))
+
+describe('PipelinePage filters', () => {
+  beforeEach(() => {
+    const leadsByFilter: Record<string, string> = {
+      default: 'Default Lead',
+      'high-value': 'High Value Lead',
+      overdue: 'Overdue Lead',
+      'this-week': 'This Week Lead',
+      'hot-leads': 'Hot Leads Lead'
+    }
+
+    global.fetch = vi.fn((url: any) => {
+      if (typeof url === 'string' && url.includes('/api/pipeline/stats')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            highValue: 1,
+            overdue: 1,
+            thisWeek: 1,
+            hotLeads: 1
+          })
+        })
+      }
+      if (typeof url === 'string' && url.includes('/api/pipeline/leads')) {
+        const params = new URL(url, 'http://localhost').searchParams
+        const filter = params.get('filter') || 'default'
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            leads: [
+              {
+                id: '1',
+                name: leadsByFilter[filter],
+                stage: 'Lead',
+                createdAt: '2024-01-01',
+                value: 100,
+                tags: []
+              }
+            ]
+          })
+        })
+      }
+      return Promise.reject(new Error('Unknown endpoint'))
+    }) as any
+  })
+
+  it('updates displayed leads when quick filters are selected', async () => {
+    render(<PipelinePage />)
+
+    await screen.findByText('Default Lead')
+
+    const filters = [
+      { id: 'high-value', label: 'High Value', result: 'High Value Lead' },
+      { id: 'overdue', label: 'Overdue', result: 'Overdue Lead' },
+      { id: 'this-week', label: 'This Week', result: 'This Week Lead' },
+      { id: 'hot-leads', label: 'Hot Leads', result: 'Hot Leads Lead' }
+    ]
+
+    for (const f of filters) {
+      fireEvent.click(screen.getByText(f.label))
+      await waitFor(() => expect(screen.getByText(f.result)).toBeInTheDocument())
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- fetch pipeline quick-filter counts and apply filters to board
- fetch inbox stats and wire tab & quick filters to inbox
- test that selecting filters changes visible items

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*


------
https://chatgpt.com/codex/tasks/task_e_68a4cf6e15948325a4b754f12421ca6e