### PR TITLE
feat: add property search widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=
 
+# API key for property search/MLS integration
+MLS_API_KEY=
+

--- a/apps/web/src/app/api/mls/route.ts
+++ b/apps/web/src/app/api/mls/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from 'next/server';
+import { auth } from '@/server/auth';
+import { searchProperties } from '@/server/mls';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const location = searchParams.get('location') || undefined;
+  const minPrice = searchParams.get('minPrice');
+  const maxPrice = searchParams.get('maxPrice');
+  const beds = searchParams.get('beds');
+
+  try {
+    const results = await searchProperties({
+      location,
+      minPrice: minPrice ? Number(minPrice) : undefined,
+      maxPrice: maxPrice ? Number(maxPrice) : undefined,
+      beds: beds ? Number(beds) : undefined,
+    });
+    return Response.json(results);
+  } catch (err) {
+    console.error('MLS search failed', err);
+    return new Response('MLS search failed', { status: 500 });
+  }
+}

--- a/apps/web/src/components/app/DashboardLayout.tsx
+++ b/apps/web/src/components/app/DashboardLayout.tsx
@@ -46,6 +46,7 @@ import LeadFeed from './LeadFeed';
 import ActivityFeed from './ActivityFeed';
 import HealthWidget from './HealthWidget';
 import MiniPipelineSparkline from './MiniPipelineSparkline';
+import PropertySearchWidget from './PropertySearchWidget';
 
 // Import drawer components
 import CardManagementDrawer from './CardManagementDrawer';
@@ -185,6 +186,20 @@ const DASHBOARD_CARDS = {
     pinned: false,
     description: 'Pipeline performance and trends',
     category: 'analytics'
+  },
+  propertySearch: {
+    id: 'propertySearch',
+    title: 'Property Search',
+    component: PropertySearchWidget,
+    minW: 4,
+    minH: 4,
+    maxW: 12,
+    maxH: 8,
+    defaultW: 6,
+    defaultH: 6,
+    pinned: false,
+    description: 'Search MLS listings',
+    category: 'leads'
   }
 };
 
@@ -200,7 +215,8 @@ const LAYOUT_PRESETS = {
         { i: 'leadFeed', x: 4, y: 2, w: 8, h: 6 },
         { i: 'activityFeed', x: 0, y: 4, w: 4, h: 4 },
         { i: 'healthWidget', x: 8, y: 2, w: 4, h: 2 },
-        { i: 'pipelineSparkline', x: 0, y: 8, w: 6, h: 2 }
+        { i: 'pipelineSparkline', x: 0, y: 8, w: 6, h: 2 },
+        { i: 'propertySearch', x: 6, y: 8, w: 6, h: 6 }
       ],
       md: [
         { i: 'todayAtGlance', x: 0, y: 0, w: 8, h: 2 },
@@ -208,7 +224,8 @@ const LAYOUT_PRESETS = {
         { i: 'leadFeed', x: 0, y: 4, w: 8, h: 6 },
         { i: 'activityFeed', x: 0, y: 10, w: 8, h: 4 },
         { i: 'healthWidget', x: 4, y: 2, w: 4, h: 2 },
-        { i: 'pipelineSparkline', x: 0, y: 14, w: 8, h: 2 }
+        { i: 'pipelineSparkline', x: 0, y: 14, w: 8, h: 2 },
+        { i: 'propertySearch', x: 0, y: 16, w: 8, h: 6 }
       ],
       sm: [
         { i: 'todayAtGlance', x: 0, y: 0, w: 4, h: 2 },
@@ -216,7 +233,8 @@ const LAYOUT_PRESETS = {
         { i: 'leadFeed', x: 0, y: 4, w: 4, h: 6 },
         { i: 'activityFeed', x: 0, y: 10, w: 4, h: 4 },
         { i: 'healthWidget', x: 0, y: 14, w: 4, h: 2 },
-        { i: 'pipelineSparkline', x: 0, y: 16, w: 4, h: 2 }
+        { i: 'pipelineSparkline', x: 0, y: 16, w: 4, h: 2 },
+        { i: 'propertySearch', x: 0, y: 18, w: 4, h: 6 }
       ]
     }
   },

--- a/apps/web/src/components/app/PropertySearchWidget.tsx
+++ b/apps/web/src/components/app/PropertySearchWidget.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from 'react';
+import { GlassCard, GlassCardContent, GlassCardHeader, GlassCardTitle } from '@/components/ui/glass-card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface Property {
+  id?: string;
+  address?: string;
+  price?: number;
+  beds?: number;
+}
+
+export default function PropertySearchWidget() {
+  const [location, setLocation] = useState('');
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+  const [beds, setBeds] = useState('');
+  const [results, setResults] = useState<Property[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [showMap, setShowMap] = useState(false);
+
+  async function search() {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (location) params.set('location', location);
+    if (minPrice) params.set('minPrice', minPrice);
+    if (maxPrice) params.set('maxPrice', maxPrice);
+    if (beds) params.set('beds', beds);
+    const res = await fetch(`/api/mls?${params.toString()}`);
+    if (res.ok) {
+      const data = await res.json();
+      setResults(Array.isArray(data) ? data : []);
+    }
+    setLoading(false);
+  }
+
+  return (
+    <GlassCard className="h-full flex flex-col" data-card-id="propertySearch">
+      <GlassCardHeader>
+        <GlassCardTitle>Property Search</GlassCardTitle>
+      </GlassCardHeader>
+      <GlassCardContent className="space-y-4 overflow-auto">
+        <div className="grid grid-cols-2 gap-2">
+          <Input placeholder="Location" value={location} onChange={e => setLocation(e.target.value)} />
+          <Input placeholder="Beds" type="number" value={beds} onChange={e => setBeds(e.target.value)} />
+          <Input placeholder="Min Price" type="number" value={minPrice} onChange={e => setMinPrice(e.target.value)} />
+          <Input placeholder="Max Price" type="number" value={maxPrice} onChange={e => setMaxPrice(e.target.value)} />
+        </div>
+        <div className="flex gap-2">
+          <Button onClick={search} disabled={loading} className="flex-1">
+            {loading ? 'Searching...' : 'Search'}
+          </Button>
+          <Button variant="outline" onClick={() => setShowMap(!showMap)}>
+            {showMap ? 'Hide Map' : 'Show Map'}
+          </Button>
+        </div>
+        <ul className="space-y-2">
+          {results.map((p, i) => (
+            <li key={i} className="text-sm">
+              <div className="font-medium">{p.address ?? 'Unknown Address'}</div>
+              <div>
+                {p.price ? `$${p.price.toLocaleString()}` : 'N/A'}
+                {p.beds ? ` · ${p.beds} beds` : ''}
+              </div>
+            </li>
+          ))}
+        </ul>
+        {showMap && (
+          <div className="h-48 w-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center text-slate-500">
+            Map placeholder
+          </div>
+        )}
+      </GlassCardContent>
+    </GlassCard>
+  );
+}
+

--- a/apps/web/src/server/env.ts
+++ b/apps/web/src/server/env.ts
@@ -24,6 +24,7 @@ export type Env = {
   POSTHOG_HOST?: string;
   OPENAI_API_KEY?: string;
   OPENAI_BASE_URL?: string;
+  MLS_API_KEY?: string;
   KMS_PROVIDER?: 'gcp'|'aws'|'azure';
   KMS_KEY_ID?: string;
   ENCRYPTION_CACHE_TTL_SECONDS: number;
@@ -60,6 +61,7 @@ export function getEnv(): Env {
     POSTHOG_HOST: env.POSTHOG_HOST,
     OPENAI_API_KEY: env.OPENAI_API_KEY,
     OPENAI_BASE_URL: env.OPENAI_BASE_URL,
+    MLS_API_KEY: env.MLS_API_KEY,
     KMS_PROVIDER: env.KMS_PROVIDER as Env['KMS_PROVIDER'],
     KMS_KEY_ID: env.KMS_KEY_ID,
     ENCRYPTION_CACHE_TTL_SECONDS: Number(env.ENCRYPTION_CACHE_TTL_SECONDS ?? 60),

--- a/apps/web/src/server/mls.ts
+++ b/apps/web/src/server/mls.ts
@@ -1,0 +1,40 @@
+import { getEnv } from './env';
+
+export interface PropertySearchFilters {
+  location?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  beds?: number;
+}
+
+const MLS_API_URL = 'https://api.example-mls.com/properties';
+
+/**
+ * Query the MLS API for property listings with the given filters.
+ */
+export async function searchProperties(filters: PropertySearchFilters) {
+  const { MLS_API_KEY } = getEnv() as { MLS_API_KEY?: string };
+  if (!MLS_API_KEY) {
+    throw new Error('MLS_API_KEY is not configured');
+  }
+
+  const params = new URLSearchParams();
+  if (filters.location) params.append('location', filters.location);
+  if (filters.minPrice) params.append('min_price', String(filters.minPrice));
+  if (filters.maxPrice) params.append('max_price', String(filters.maxPrice));
+  if (filters.beds) params.append('beds', String(filters.beds));
+
+  const res = await fetch(`${MLS_API_URL}?${params.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${MLS_API_KEY}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`MLS API request failed with ${res.status}`);
+  }
+
+  const data = await res.json();
+  return data.listings ?? data;
+}
+


### PR DESCRIPTION
## Summary
- add server-side MLS query function
- implement PropertySearchWidget and register in dashboard
- document MLS_API_KEY in .env.example
- revert README changes to avoid binary diff

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc8730548325bc431b8432919f14