### PR TITLE
feat(web): add dynamic social proof stats and logos

### DIFF
--- a/apps/web/src/app/api/marketing/stats/route.ts
+++ b/apps/web/src/app/api/marketing/stats/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  // In a real application these values could come from a database or external service
+  return NextResponse.json({
+    agents: 500,
+    deals: 2.4,
+    satisfaction: 98,
+  });
+}


### PR DESCRIPTION
## Summary
- display brand logos with accessible alt text
- load social proof stats from `/api/marketing/stats`
- animate counters to fetched values

## Testing
- `npm run lint` *(fails: recursive_turbo_invocations)*
- `npm test` *(fails: recursive_turbo_invocations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e711dce88325b82fe8e0e8b7ba32