### PR TITLE
Add OAuth trust note below sign-in buttons

### DIFF
--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -191,6 +191,11 @@ export default function SignInPage() {
             )}
           </div>
 
+          <div className="flex items-center justify-center text-xs text-muted-foreground space-x-2 animate-fade-up-delay-4">
+            <Shield className="w-4 h-4" aria-hidden="true" />
+            <span>We use OAuth 2.0 and never store your password.</span>
+          </div>
+
           <div className="text-center animate-fade-up-delay-4">
             <p className="text-xs text-muted-foreground leading-relaxed">
               By continuing you agree to our{" "}


### PR DESCRIPTION
## Summary
- Add muted OAuth trust line with shield icon below sign-in options

## Testing
- `npm test` *(fails: recursive turbo invocations)*
- `npm run lint` *(fails: recursive turbo invocations)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e7197b9883258388fac0f45285e3