### PR TITLE
feat: improve sign-in button accessibility

### DIFF
--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -124,10 +124,11 @@ export default function SignInPage() {
                 onClick={() => handleSignIn('google')}
                 disabled={isSigningIn}
                 className="btn-primary hover-lift focus-flow w-full group relative flex items-center justify-center px-6 py-4 text-base font-medium rounded-lg text-white bg-[#4285F4] hover:bg-[#3367D6] disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 animate-fade-up-delay-2"
-                aria-label="Sign in with Google. We never store your password; sign-in happens with your provider."
+                aria-label="Sign in with Google"
                 aria-describedby={error ? "error-description" : undefined}
               >
                 <svg className="w-5 h-5 mr-3" viewBox="0 0 24 24" aria-hidden="true">
+                  <title>Google</title>
                   <path fill="#FFFFFF" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
                   <path fill="#FFFFFF" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
                   <path fill="#FFFFFF" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
@@ -154,10 +155,11 @@ export default function SignInPage() {
                 onClick={() => handleSignIn('azure-ad')}
                 disabled={isSigningIn}
                 className="btn-primary hover-lift focus-flow w-full group relative flex items-center justify-center px-6 py-4 text-base font-medium rounded-lg text-white bg-[#0078D4] hover:bg-[#106EBE] disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 animate-fade-up-delay-3"
-                aria-label="Sign in with Microsoft. We never store your password; sign-in happens with your provider."
+                aria-label="Sign in with Microsoft"
                 aria-describedby={error ? "error-description" : undefined}
               >
                 <svg className="w-5 h-5 mr-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <title>Microsoft</title>
                   <path d="M11.4 24H0V12.6h11.4V24zM24 24H12.6V12.6H24V24zM11.4 11.4H0V0h11.4v11.4zM24 11.4H12.6V0H24v11.4z"/>
                 </svg>
                 {isSigningIn && signInProvider === 'azure-ad' ? (


### PR DESCRIPTION
## Summary
- add descriptive titles to Google and Microsoft sign-in SVG icons
- simplify aria-labels to clearly announce provider actions

## Testing
- `npm test` *(fails: recursive turbo invocation)*
- `npm run lint` *(fails: recursive turbo invocation)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e71b85ac83259f2d15d5ab117079